### PR TITLE
refactor: ワークフローを責任分離の原則に従って分割

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ${{ matrix.os }}
-    if: github.event.release.target_commitish == 'main'
+    if: github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,15 @@
-name: Build and Deploy
+name: Release to PyPI
 
 on:
   release:
     types: [published]
-  pull_request:
-    types: [opened, synchronize, reopened]
-  workflow_dispatch: # 手動実行も可能にする
 
 jobs:
-  build-and-deploy:
+  publish:
     runs-on: ${{ matrix.os }}
+    if: github.event.release.target_commitish == 'main'
     strategy:
-      fail-fast: false # 一つの環境のビルド失敗で全体が止まらないようにする
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.11"]
@@ -25,9 +23,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # バージョン確認ステップ（リリース時のみ実行）
+      # バージョン確認ステップ
       - name: Check versions
-        if: github.event_name == 'release'
         shell: bash
         run: |
           # Gitタグからバージョンを取得（v0.0.1 -> 0.0.1）
@@ -70,81 +67,10 @@ jobs:
       - name: Setup Windows dependencies
         if: matrix.os == 'windows-latest'
         run: |
-          # Windowsでは基本的なツールのみ必要
           choco install cmake -y
 
-      # maturinを使用してホイールをビルド (GitHub Actionsのみ)
-      - name: Build wheels with maturin-action
-        uses: PyO3/maturin-action@v1
-        if: false # このステップはスキップ - 代わりに直接maturin developを使用
-        with:
-          target: ${{ matrix.os == 'windows-latest' && 'x86_64-pc-windows-msvc' || 'x86_64' }}
-          args: --release --strip
-          manylinux: auto
-          container: off
-        env:
-          RUST_BACKTRACE: 1
-
-      # ビルドしてインストール (maturin developを使用)
-      - name: Build and install with maturin develop
-        shell: bash
-        run: |
-          # 環境情報を表示
-          echo "Building environment info:"
-          python --version
-          rustc --version
-
-          # 仮想環境を認識できるようにする
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            # Windowsでの処理
-            export VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
-          else
-            # Linux/Macでの処理
-            export VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
-          fi
-          echo "Setting VIRTUAL_ENV=$VIRTUAL_ENV"
-
-          # maturinをインストール
-          pip install maturin
-
-          # maturin developでビルド・インストール
-          VIRTUAL_ENV=$VIRTUAL_ENV maturin develop
-
-          # インストールされたモジュールを確認
-          echo "インストールされたパッケージ:"
-          pip list
-
-          # Pythonモジュールパスとモジュール構造を確認
-          python -c "import sys; print('Python module paths:'); [print(p) for p in sys.path]"
-          python -c "import rustgression; print('Rustgression module location:', rustgression.__file__)"
-
-      # パッケージのインポートテスト
-      - name: Test import
-        shell: bash
-        run: |
-          python scripts/test-import-operation.py
-
-      # テストの実行
-      - name: Run tests
-        shell: bash
-        run: |
-          # インポートできる場合だけテストを実行
-          python -c "import rustgression" && python -m pytest || {
-            echo "Skipping tests due to import failure"
-          }
-
-      # ビルド成果物をアップロード（PRとワークフロー手動実行時のみ）
-      - name: Upload wheels as artifacts
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
-          path: target/wheels/*.whl
-          retention-days: 7
-
-      # PyPIへの公開（リリース時のみ）
+      # PyPIへの公開
       - name: Publish to PyPI
-        if: github.event_name == 'release'
         shell: bash
         run: |
           echo "Building wheels for release..."

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -44,8 +44,8 @@ jobs:
           # Windowsでは基本的なツールのみ必要
           choco install cmake -y
 
-      # ビルドしてインストール (maturin developを使用)
-      - name: Build and install with maturin develop
+      # ビルドとインストール
+      - name: Build wheels and install
         shell: bash
         run: |
           # 環境情報を表示
@@ -53,21 +53,18 @@ jobs:
           python --version
           rustc --version
 
-          # 仮想環境を認識できるようにする
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            # Windowsでの処理
-            export VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
-          else
-            # Linux/Macでの処理
-            export VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
-          fi
-          echo "Setting VIRTUAL_ENV=$VIRTUAL_ENV"
-
           # maturinをインストール
           pip install maturin
 
-          # maturin developでビルド・インストール
-          VIRTUAL_ENV=$VIRTUAL_ENV maturin develop
+          # ホイールをビルド
+          maturin build --release
+
+          # ビルドされたホイールを確認
+          echo "Built wheels:"
+          ls -la target/wheels/ || echo "No wheels directory found"
+
+          # 開発用インストール（テスト用）
+          maturin develop
 
           # インストールされたモジュールを確認
           echo "インストールされたパッケージ:"
@@ -87,10 +84,14 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          # インポートできる場合だけテストを実行
-          python -c "import rustgression" && python -m pytest || {
-            echo "Skipping tests due to import failure"
-          }
+          # インポートテスト（失敗時はワークフローを失敗させる）
+          if ! python -c "import rustgression"; then
+            echo "Import failed: rustgression module not found."
+            exit 1
+          fi
+          
+          # テスト実行
+          python -m pytest
 
       # ビルド成果物をアップロード
       - name: Upload wheels as artifacts

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -63,8 +63,8 @@ jobs:
           echo "Built wheels:"
           ls -la target/wheels/ || echo "No wheels directory found"
 
-          # 開発用インストール（テスト用）
-          maturin develop
+          # ビルドされたホイールをインストール（テスト用）
+          pip install target/wheels/*.whl
 
           # インストールされたモジュールを確認
           echo "インストールされたパッケージ:"

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,0 +1,101 @@
+name: Test and Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch: # 手動実行も可能にする
+
+jobs:
+  test-and-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # 一つの環境のビルド失敗で全体が止まらないようにする
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      # Linux環境のセットアップ（Ubuntu）
+      - name: Setup Ubuntu dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake
+
+      # Windows環境のセットアップ
+      - name: Setup Windows dependencies
+        if: matrix.os == 'windows-latest'
+        run: |
+          # Windowsでは基本的なツールのみ必要
+          choco install cmake -y
+
+      # ビルドしてインストール (maturin developを使用)
+      - name: Build and install with maturin develop
+        shell: bash
+        run: |
+          # 環境情報を表示
+          echo "Building environment info:"
+          python --version
+          rustc --version
+
+          # 仮想環境を認識できるようにする
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            # Windowsでの処理
+            export VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
+          else
+            # Linux/Macでの処理
+            export VIRTUAL_ENV=$(python -c "import sys; print(sys.prefix)")
+          fi
+          echo "Setting VIRTUAL_ENV=$VIRTUAL_ENV"
+
+          # maturinをインストール
+          pip install maturin
+
+          # maturin developでビルド・インストール
+          VIRTUAL_ENV=$VIRTUAL_ENV maturin develop
+
+          # インストールされたモジュールを確認
+          echo "インストールされたパッケージ:"
+          pip list
+
+          # Pythonモジュールパスとモジュール構造を確認
+          python -c "import sys; print('Python module paths:'); [print(p) for p in sys.path]"
+          python -c "import rustgression; print('Rustgression module location:', rustgression.__file__)"
+
+      # パッケージのインポートテスト
+      - name: Test import
+        shell: bash
+        run: |
+          python scripts/test-import-operation.py
+
+      # テストの実行
+      - name: Run tests
+        shell: bash
+        run: |
+          # インポートできる場合だけテストを実行
+          python -c "import rustgression" && python -m pytest || {
+            echo "Skipping tests due to import failure"
+          }
+
+      # ビルド成果物をアップロード
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: target/wheels/*.whl
+          retention-days: 7

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -53,8 +53,11 @@ jobs:
           python --version
           rustc --version
 
-          # maturinをインストール
-          pip install maturin
+          # pyproject.tomlから依存関係をインストール
+          pip install -e .
+          
+          # 開発・テスト用依存関係を個別にインストール
+          pip install maturin pytest
 
           # ホイールをビルド
           maturin build --release
@@ -62,9 +65,6 @@ jobs:
           # ビルドされたホイールを確認
           echo "Built wheels:"
           ls -la target/wheels/ || echo "No wheels directory found"
-
-          # ビルドされたホイールをインストール（テスト用）
-          pip install target/wheels/*.whl
 
           # インストールされたモジュールを確認
           echo "インストールされたパッケージ:"


### PR DESCRIPTION
## Summary
- `deploy.yml`を削除し、責任分離の原則に従って2つのワークフローに分割
- `test-and-build.yml`: PR時のテスト・ビルド・成果物検証を担当
- `release.yml`: リリース時のPyPI公開を担当（mainブランチからのリリース限定）

## Benefits
- 関心の分離により保守性向上
- PRではテストのみ実行でCI時間短縮
- リリース時のみPyPI公開でセキュリティ向上
- PyPI APIトークンの露出リスク最小化

## Test plan
- [x] PR作成時にtest-and-buildワークフローが正常に動作することを確認
- [ ] リリース作成時にreleaseワークフローが正常に動作することを確認
- [x] mainブランチ以外からのリリースがブロックされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)