### PR TITLE
Release v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "rustgression"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cargo-tarpaulin",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustgression"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["connect0459 <connect0459@gmail.com>"]
 description = "Fast OLS and TLS regression using Rust backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rustgression"
-version = "0.2.0"
+version = "0.2.1"
 description = "Fast OLS and TLS and regression using Rust backend"
 authors = [{ name = "connect0459", email = "connect0459@gmail.com" }]
 readme = "README.md"

--- a/rustgression/__init__.py
+++ b/rustgression/__init__.py
@@ -39,7 +39,7 @@ Examples
 """
 
 # Package version
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # Check availability of Rust module (actual import is done in _rust_imports.py)
 try:

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# バージョン更新スクリプト
+# 使用法: ./scripts/update-version.sh <new_version>
+# 例: ./scripts/update-version.sh 0.2.1
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "使用法: $0 <new_version>"
+    echo "例: $0 0.2.1"
+    exit 1
+fi
+
+NEW_VERSION=$1
+
+# バージョン形式をチェック (semver形式、プレリリース対応)
+if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+|-beta\.[0-9]+|-rc\.[0-9]+)?$ ]]; then
+    echo "エラー: バージョンはsemver形式で指定してください"
+    echo "例: 1.0.0, 1.0.0-alpha.1, 1.0.0-beta.2, 1.0.0-rc.1"
+    exit 1
+fi
+
+echo "バージョンを $NEW_VERSION に更新します..."
+
+# 1. rustgression/__init__.py の __version__ を更新 (alpha/beta形式を変換)
+echo "rustgression/__init__.py を更新中..."
+PYTHON_VERSION=$(echo "$NEW_VERSION" | sed 's/-alpha\./.a/' | sed 's/-beta\./.b/' | sed 's/-rc\./.rc/')
+sed -i.bak "s/__version__ = \".*\"/__version__ = \"$PYTHON_VERSION\"/" rustgression/__init__.py
+
+# 2. Cargo.toml のバージョンを更新
+echo "Cargo.toml を更新中..."
+sed -i.bak "s/^version = \".*\"/version = \"$NEW_VERSION\"/" Cargo.toml
+
+# 3. pyproject.toml のバージョンを更新 (alpha/beta形式を変換)
+echo "pyproject.toml を更新中..."
+sed -i.bak "s/^version = \".*\"/version = \"$PYTHON_VERSION\"/" pyproject.toml
+
+# 4. Cargo.lock を更新 (cargoコマンドでプロジェクトをチェック)
+echo "Cargo.lock を更新中..."
+cargo check --quiet
+
+# 5. uv.lock を更新 (uvコマンドでプロジェクトの依存関係を同期)
+echo "uv.lock を更新中..."
+if command -v uv >/dev/null 2>&1; then
+    uv lock
+else
+    echo "警告: uvコマンドが見つかりません。uv.lockの更新をスキップします。"
+fi
+
+# バックアップファイルを削除
+rm -f rustgression/__init__.py.bak Cargo.toml.bak pyproject.toml.bak
+
+echo "✅ バージョン更新が完了しました: $NEW_VERSION"
+echo ""
+echo "更新されたファイル:"
+echo "- rustgression/__init__.py (Python形式: $PYTHON_VERSION)"
+echo "- Cargo.toml (Rust形式: $NEW_VERSION)"
+echo "- pyproject.toml (Python形式: $PYTHON_VERSION)"
+echo "- Cargo.lock"
+if command -v uv >/dev/null 2>&1; then
+    echo "- uv.lock"
+fi
+echo ""
+echo "次の手順:"
+echo "1. 変更内容を確認: git diff"
+echo "2. テストを実行: cargo test && python -m pytest"
+echo "3. 変更をコミット: git add . && git commit -m \"chore: bump version to $NEW_VERSION\""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -1109,7 +1109,7 @@ wheels = [
 
 [[package]]
 name = "rustgression"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary
- v0.2.1へのバージョンアップ
- バージョン更新用のshスクリプトを追加（プレリリース版対応）
- RustとPythonのバージョン形式変換に対応

## Changes
- `rustgression/__init__.py`のバージョンを0.2.1に更新
- `Cargo.toml`のバージョンを0.2.1に更新
- `pyproject.toml`のバージョンを0.2.1に更新
- `scripts/update-version.sh`を追加（alpha/beta版のバージョン形式変換機能付き）

## Test plan
- [ ] `cargo test` でRustテストが通ることを確認
- [ ] `python -m pytest` でPythonテストが通ることを確認
- [ ] バージョン更新スクリプトが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)