### PR TITLE
docs: Fix section titles in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 This project provides fast regression analysis (OLS, TLS) as a Python package.
 
-- WebSite: <https://pypi.org/project/rustgression/>
-- Documentation: <https://github.com/connect0459/rustgression/blob/main/README.md>
-- Source code: <https://github.com/connect0459/rustgression>
-- Report bugs or security vulnerabilities: <https://github.com/connect0459/rustgression/issues>
+- **WebSite**: <https://pypi.org/project/rustgression/>
+- **Documentation**: <https://github.com/connect0459/rustgression/blob/main/README.md>
+- **Source code**: <https://github.com/connect0459/rustgression>
+- **Bug reports and security issues**: <https://github.com/connect0459/rustgression/issues>
 
 ## Overview
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -7,7 +7,7 @@ This project provides fast regression analysis (OLS, TLS) as a Python package.
 - **WebSite**: <https://pypi.org/project/rustgression/>
 - **Documentation**: <https://github.com/connect0459/rustgression/blob/main/README.md>
 - **Source code**: <https://github.com/connect0459/rustgression>
-- **Report bugs or security vulnerabilities**: <https://github.com/connect0459/rustgression/issues>
+- **Bug reports and security issues**: <https://github.com/connect0459/rustgression/issues>
 
 ## Overview
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -7,7 +7,7 @@
 - **WebSite**: <https://pypi.org/project/rustgression/>
 - **Documentation**: <https://github.com/connect0459/rustgression/blob/main/README.md>
 - **Source code**: <https://github.com/connect0459/rustgression>
-- **Report bugs or security vulnerabilities**: <https://github.com/connect0459/rustgression/issues>
+- **Bug reports and security issues**: <https://github.com/connect0459/rustgression/issues>
 
 ## 概要
 


### PR DESCRIPTION
## Summary
- README文書のセクションタイトルを命令形から名詞形に修正
- より適切な英語表現に統一

## Changes
- `**Report bugs or security vulnerabilities**` → `**Bug reports and security issues**`
- 対象ファイル:
  - `README.md`
  - `docs/ja/README.md` 
  - `docs/en/README.md`

## Rationale
- 命令形（Report）よりも名詞形（Bug reports）の方がセクション見出しとして自然
- GitHubの公式ドキュメントや多くのOSSプロジェクトで使用されている一般的な表現に統一

## Test plan
- [ ] ドキュメントの表示を確認
- [ ] リンクが正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)