### PR TITLE
Release v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "rustgression"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cargo-tarpaulin",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustgression"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["connect0459 <connect0459@gmail.com>"]
 description = "Fast OLS and TLS regression using Rust backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rustgression"
-version = "0.2.1"
+version = "0.2.2"
 description = "Fast OLS and TLS and regression using Rust backend"
 authors = [{ name = "connect0459", email = "connect0459@gmail.com" }]
 readme = "README.md"

--- a/rustgression/__init__.py
+++ b/rustgression/__init__.py
@@ -39,7 +39,7 @@ Examples
 """
 
 # Package version
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 # Check availability of Rust module (actual import is done in _rust_imports.py)
 try:

--- a/uv.lock
+++ b/uv.lock
@@ -1109,7 +1109,7 @@ wheels = [
 
 [[package]]
 name = "rustgression"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary
- v0.2.2へのバージョンアップ
- version管理スクリプトを使用してバージョンを統一更新

## Changes
- `rustgression/__init__.py`のバージョンを0.2.2に更新
- `Cargo.toml`のバージョンを0.2.2に更新
- `pyproject.toml`のバージョンを0.2.2に更新
- `Cargo.lock`を更新
- `uv.lock`を更新

## Notes
- `scripts/update-version.sh 0.2.2`を使用してバージョンを統一更新
- 前回のv0.2.2リリースではversion管理スクリプトの適用を忘れていたため、再作成

## Test plan
- [ ] `docker compose exec -w /workspace rustgression-dev cargo test` でRustテストが通ることを確認
- [ ] `docker compose exec -w /workspace rustgression-dev uv run pytest` でPythonテストが通ることを確認
- [ ] バージョン情報が正しく更新されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)