### PR TITLE
ci: Restructure release workflow into 3 distinct steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,28 @@ on:
 run-name: Release to PyPI ${{ github.event.release.tag_name }}
 
 jobs:
-  # Step 1: 全プラットフォームでビルド
-  build:
-    runs-on: ${{ matrix.os }}
+  # Step 1: Version consistency check
+  version-check:
+    runs-on: ubuntu-latest
     if: github.event.release.target_commitish == 'main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version consistency
+        shell: bash
+        run: |
+          # Extract version from release tag (v0.0.1 -> 0.0.1)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          ./scripts/version-check.sh "$VERSION"
+
+  # Step 2: Build wheels for all platforms
+  build:
+    needs: version-check
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,14 +39,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           fetch-depth: 0
-
-      # バージョン確認ステップ
-      - name: Check version consistency
-        shell: bash
-        run: |
-          # Extract version from release tag (v0.0.1 -> 0.0.1)
-          VERSION=${GITHUB_REF#refs/tags/v}
-          ./scripts/version-check.sh "$VERSION"
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v5
@@ -95,9 +105,9 @@ jobs:
           path: target/wheels/*.whl
           retention-days: 1
 
-  # Step 2: 全てのビルドが成功した後に一括パブリッシュ
+  # Step 3: Publish all wheels to PyPI after successful builds
   publish:
-    needs: build
+    needs: [version-check, build]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Overview

Restructuring the GitHub Actions release workflow to improve clarity, efficiency, and maintainability by separating concerns into 3 distinct sequential steps.

## Changes Made

### 🔄 Workflow Restructure

**Step 1: Version Consistency Check**
- Separated version validation into an independent job
- Runs on Ubuntu for fast execution
- Acts as a gatekeeper for subsequent steps
- Prevents resource waste if version validation fails

**Step 2: Multi-Platform Build**
- Executes only after version check passes
- Parallel builds across Ubuntu, macOS, and Windows
- Eliminates redundant version checking on each platform
- Maintains existing build logic and artifact uploads

**Step 3: PyPI Publishing**
- Depends on both version-check and build job success
- Downloads and publishes all platform wheels
- Maintains existing security and publishing logic

### 🚀 Improvements

- **Early Failure Detection** - Version issues caught before expensive builds
- **Resource Efficiency** - No unnecessary platform builds on version failures
- **Clear Separation of Concerns** - Each step has a single responsibility
- **Better Dependency Management** - Explicit job dependencies with `needs` array
- **Consistent English Comments** - Updated all comments for international collaboration

### 🔧 Technical Details

- **Job Dependencies**: `version-check` → `build` → `publish`
- **Parallel Execution**: Build jobs still run in parallel across platforms
- **Artifact Management**: Unchanged - maintains compatibility with existing setup
- **Security**: No changes to permissions or secrets handling

## Quality Assurance

- [x] Workflow syntax validated
- [x] Job dependencies correctly configured
- [x] All existing functionality preserved
- [x] Comments updated to English
- [x] No breaking changes to build or publish logic

## Testing

This change maintains full backward compatibility with existing release processes. The workflow will:
1. Validate versions first (fast fail)
2. Build wheels for all platforms if validation passes
3. Publish to PyPI only if all builds succeed

🤖 Generated with [Claude Code](https://claude.ai/code)