### PR TITLE
fix: Add explicit license field to resolve PyPI metadata error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.4.1"
 description = "Fast OLS and TLS regression using Rust backend"
 authors = [{ name = "connect0459", email = "connect0459@gmail.com" }]
 readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Problem

The v0.4.1 release failed with the following PyPI upload error:
```
ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or    
         malformed field 'license-file'
```

## Root Cause

This error occurs when the package metadata contains the deprecated `license-file` field instead of the current PEP 621 standard `license` field specification.

## Solution

- **Added explicit license field**: `license = { file = "LICENSE" }` to `pyproject.toml`
- **Follows PEP 621 standard**: Uses the current Python packaging metadata specification
- **References existing LICENSE file**: Points to the MIT license file already present in the repository

## Technical Details

### Before (Implicit/Deprecated)
- No explicit license field in pyproject.toml
- Relied on build tools to infer license metadata
- Could generate deprecated `license-file` metadata

### After (PEP 621 Compliant) 
```toml
license = { file = "LICENSE" }
```
- Explicit license field specification
- Follows current Python packaging standards
- Generates correct metadata for PyPI

## Testing

- [x] LICENSE file exists and is properly formatted
- [x] pyproject.toml syntax is valid
- [x] Pre-commit checks pass
- [x] Follows PEP 621 specification

## Impact

- **Fixes PyPI upload error**: Resolves the metadata validation failure
- **No breaking changes**: Maintains full backward compatibility
- **Future-proof**: Uses current packaging standards
- **License compliance**: Ensures proper license metadata distribution

This is a hotfix that should be merged immediately to enable successful v0.4.1 PyPI publication.

## References

- [PEP 621 – Storing project metadata in pyproject.toml](https://peps.python.org/pep-0621/)
- [PyPA Packaging User Guide - License](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)

🤖 Generated with [Claude Code](https://claude.ai/code)