### PR TITLE
chore: update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--maxkb=500]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.13
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,24 @@
-# Pre-commit configuration for rustgression
 repos:
-  # Python formatting and linting with Ruff
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-toml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+        args: [--maxkb=500]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.13
     hooks:
-      # Run the linter
       - id: ruff
         args: [--fix]
-      # Run the formatter
       - id: ruff-format
 
-  # Rust formatting and linting
   - repo: local
     hooks:
-      # Rust formatting with rustfmt
       - id: rust-fmt
         name: rust fmt
         entry: cargo fmt
@@ -21,8 +26,6 @@ repos:
         files: \.rs$
         pass_filenames: false
         args: [--all, --check]
-
-      # Rust linting with clippy
       - id: rust-clippy
         name: rust clippy
         entry: cargo clippy
@@ -30,21 +33,3 @@ repos:
         files: \.rs$
         pass_filenames: false
         args: [--all-targets, --all-features, --, -D, warnings]
-
-  # General pre-commit hooks
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      # Check for merge conflicts
-      - id: check-merge-conflict
-      # Check YAML syntax
-      - id: check-yaml
-      # Check TOML syntax
-      - id: check-toml
-      # Remove trailing whitespace
-      - id: trailing-whitespace
-      # Ensure files end with newline
-      - id: end-of-file-fixer
-      # Check for large files
-      - id: check-added-large-files
-        args: [--maxkb=500]


### PR DESCRIPTION
## Summary

Reorganized hook ordering and updated ruff in `.pre-commit-config.yaml`.

## Details

| Change | Before | After |
|---|---|---|
| Hook order | general hooks ran last | general hooks run first |
| ruff version | `v0.14.13` | `v0.15.12` |
| Comments | inline comments present | removed |

**Hook order change** ensures generic checks (merge conflict, YAML/TOML syntax, trailing whitespace, large files) run before language-specific linters and formatters.

## Release

- When: Anytime

## Post-deployment Verification

- CI passing is sufficient; no functional changes to linting rules
- Rollback: Revert