### PR TITLE
docs: split ci type out of chore in commit conventions

### DIFF
--- a/docs/COMMIT_CONVENTIONS.md
+++ b/docs/COMMIT_CONVENTIONS.md
@@ -21,7 +21,8 @@
 | `refactor` | Code change that is neither a fix nor a feature |
 | `tidy` | Small, safe cleanup (< 2 min; no behavior change) |
 | `test` | Adding or updating tests |
-| `chore` | Build process, tooling, config, CI/CD pipeline changes |
+| `chore` | Build process, tooling, or config changes |
+| `ci` | CI/CD pipeline changes (GitHub Actions, workflows) |
 | `perf` | Performance improvement |
 
 ## Scopes


### PR DESCRIPTION
## [Required] Overview

`ci:` was previously subsumed under `chore:`. GitHub Actions and other CI/CD workflow changes are conventionally categorised as `ci:` — a standard type in the Conventional Commits specification — so the two are now separated. `chore:` retains build process, tooling, and config changes; `ci:` covers CI/CD pipeline files (GitHub Actions, workflows).

## [Required] Release

- Release date
  - Anytime
- Release considerations
  - Nothing

## Post-Release Verification

- No functional changes; CI passing is sufficient.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [ ] Design decisions documented in ADR (if applicable)
- [ ] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.

## Work Time

- Estimate
  - 0.5 hours
- Actual time spent
  - 0.5 hours
- Reason for time difference (over/under estimate)
  - (fill in)