### PR TITLE
test(ols): add double-validation tests against scipy.stats.linregress

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,6 @@ dev = [
   "pytest==9.0.3",
   "pytest-cov==7.1.0",
   "ruff==0.15.14",
+  "scipy>=1.15.2",
   "setuptools==82.0.1",
 ]

--- a/tests/test_ols_double_validation.py
+++ b/tests/test_ols_double_validation.py
@@ -1,0 +1,88 @@
+"""
+Double-Validation tests for OLS regression against scipy.stats.linregress.
+"""
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from rustgression import OlsRegressor
+
+
+@pytest.fixture
+def standard_noisy_data():
+    np.random.seed(42)
+    x = np.linspace(0, 10, 100)
+    y = 2.0 * x + 1.0 + np.random.normal(0, 0.5, 100)
+    return x, y
+
+
+@pytest.fixture
+def perfect_linear_data():
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    y = 3.0 * x + 2.5
+    return x, y
+
+
+@pytest.fixture
+def negatively_correlated_data():
+    np.random.seed(99)
+    x = np.linspace(0, 10, 100)
+    y = -1.5 * x + 8.0 + np.random.normal(0, 0.3, 100)
+    return x, y
+
+
+@pytest.fixture
+def high_condition_number_data():
+    np.random.seed(7)
+    x = np.linspace(10000, 10100, 200)
+    y = 2.5 * x - 24900.0 + np.random.normal(0, 1.0, 200)
+    return x, y
+
+
+class TestOlsDoubleValidation:
+    """Double-Validation tests comparing OLS outputs against scipy.stats.linregress."""
+
+    def test_ols_produces_accurate_slope_intercept_and_r_value_for_standard_noisy_data(
+        self, standard_noisy_data
+    ):
+        x, y = standard_noisy_data
+        ref_slope, ref_intercept, ref_r_value, _, _ = stats.linregress(x, y)
+        ols = OlsRegressor(x, y)
+
+        assert abs(ols.slope() - ref_slope) < 1e-10
+        assert abs(ols.intercept() - ref_intercept) < 1e-10
+        assert abs(ols.r_value() - ref_r_value) < 1e-10
+
+    def test_ols_produces_exact_parameters_for_perfectly_linear_data(
+        self, perfect_linear_data
+    ):
+        x, y = perfect_linear_data
+        ref_slope, ref_intercept, ref_r_value, _, _ = stats.linregress(x, y)
+        ols = OlsRegressor(x, y)
+
+        assert abs(ols.slope() - ref_slope) < 1e-10
+        assert abs(ols.intercept() - ref_intercept) < 1e-10
+        assert abs(ols.r_value() - ref_r_value) < 1e-10
+
+    def test_ols_produces_accurate_slope_intercept_and_r_value_for_negatively_correlated_data(
+        self, negatively_correlated_data
+    ):
+        x, y = negatively_correlated_data
+        ref_slope, ref_intercept, ref_r_value, _, _ = stats.linregress(x, y)
+        ols = OlsRegressor(x, y)
+
+        assert abs(ols.slope() - ref_slope) < 1e-10
+        assert abs(ols.intercept() - ref_intercept) < 1e-10
+        assert abs(ols.r_value() - ref_r_value) < 1e-10
+
+    def test_ols_maintains_numerical_accuracy_under_high_condition_number(
+        self, high_condition_number_data
+    ):
+        x, y = high_condition_number_data
+        ref_slope, ref_intercept, ref_r_value, _, _ = stats.linregress(x, y)
+        ols = OlsRegressor(x, y)
+
+        assert abs(ols.slope() - ref_slope) < 1e-6
+        assert abs(ols.intercept() - ref_intercept) < 1e-6
+        assert abs(ols.r_value() - ref_r_value) < 1e-6

--- a/uv.lock
+++ b/uv.lock
@@ -1188,6 +1188,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scipy" },
     { name = "setuptools" },
     { name = "twine" },
 ]
@@ -1211,6 +1212,7 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.15.14" },
+    { name = "scipy", specifier = ">=1.15.2" },
     { name = "setuptools", specifier = "==82.0.1" },
     { name = "twine", specifier = "==6.2.0" },
 ]


### PR DESCRIPTION
<!-- # test(ols): add double-validation tests against scipy.stats.linregress -->

## Related URLs

- Closes #139

## [Required] Overview

The OLS test suite previously verified only internal consistency — comparisons between methods and fits to synthetic data. There was no check that outputs numerically agree with an established external implementation.

This PR introduces Double-Validation tests that assert OLS regression outputs match a reference implementation within tight tolerances across four scenarios: standard noisy data, perfectly linear data, negatively correlated data, and a dataset with a large design-matrix condition number where numerical drift is most likely to surface. scipy is added to the dev dependency group to support these tests.

## [Required] Release

- Release date
  - Anytime
- Release considerations
  - Nothing

## Post-Release Verification

- No functional changes; CI passing is sufficient.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [ ] Design decisions documented in ADR (if applicable)
- [ ] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
