### PR TITLE
fix(tls): raise error when v_nn y-component is below stability threshold

### DIFF
--- a/src/regression/tls.rs
+++ b/src/regression/tls.rs
@@ -184,6 +184,16 @@ fn calculate_slope_with_sign_correction(
     x_mean: f64,
     y_mean: f64,
 ) -> PyResult<(f64, f64)> {
+    let stability_threshold = f64::EPSILON.sqrt();
+    if v_col[1].abs() < stability_threshold {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "TLS regression is numerically unstable: null-vector y-component \
+             magnitude ({:.2e}) is below the stability threshold ({:.2e}). \
+             The data may represent a nearly vertical or uncorrelated relationship.",
+            v_col[1].abs(),
+            stability_threshold
+        )));
+    }
     let mut slope = safe_divide(-v_col[0], v_col[1], "TLS slope calculation")?;
 
     let mut covariance = 0.0;

--- a/tests/test_tls_numerical_stability.py
+++ b/tests/test_tls_numerical_stability.py
@@ -1,0 +1,35 @@
+"""
+Numerical stability tests for TLS regression.
+"""
+
+import numpy as np
+import pytest
+
+from rustgression import TlsRegressor
+
+
+class TestTlsNumericalStability:
+    """Tests that verify TLS regression handles numerically unstable inputs safely."""
+
+    def test_raises_error_when_tls_problem_is_numerically_unstable_due_to_extreme_slope(
+        self,
+    ):
+        np.random.seed(42)
+        x = np.linspace(0, 1e-10, 50) + np.random.normal(0, 1e-12, 50)
+        y = np.linspace(0, 1.0, 50)
+        with pytest.raises((ValueError, RuntimeError)):
+            TlsRegressor(x, y)
+
+    def test_produces_accurate_slope_for_data_with_moderate_noise(self):
+        np.random.seed(42)
+        x = np.linspace(0, 10, 100)
+        y = 2.0 * x + 1.0 + np.random.normal(0, 0.5, 100)
+        regressor = TlsRegressor(x, y)
+        assert 1.9 < regressor.slope() < 2.1
+
+    def test_produces_accurate_slope_for_strongly_correlated_data(self):
+        np.random.seed(0)
+        x = np.linspace(0, 10, 50)
+        y = 3.0 * x + 5.0 + np.random.normal(0, 0.01, 50)
+        regressor = TlsRegressor(x, y)
+        assert abs(regressor.slope() - 3.0) < 0.01

--- a/tests/test_tls_numerical_stability.py
+++ b/tests/test_tls_numerical_stability.py
@@ -17,7 +17,7 @@ class TestTlsNumericalStability:
         np.random.seed(42)
         x = np.linspace(0, 1e-10, 50) + np.random.normal(0, 1e-12, 50)
         y = np.linspace(0, 1.0, 50)
-        with pytest.raises((ValueError, RuntimeError)):
+        with pytest.raises(RuntimeError, match="numerically unstable"):
             TlsRegressor(x, y)
 
     def test_produces_accurate_slope_for_data_with_moderate_noise(self):


### PR DESCRIPTION
<!-- # fix(tls): raise error when v_nn y-component is below stability threshold -->

## Related URLs

- Closes #140

## [Required] Overview

TLS regression previously produced astronomically large, meaningless slopes when the null-vector y-component fell below the machine epsilon range — for example, when the x-range of the input is on the order of 1e-10 while y spans a normal range. Instead of silently returning an unreliable result, TLS now raises a `RuntimeError` with a descriptive message when the null-vector y-component magnitude falls below `sqrt(EPSILON)`. This gives callers a clear signal to detect and handle nearly-vertical or uncorrelated input data.

## [Required] Release

- Release date
  - Anytime
- Release considerations
  - This is a breaking change for inputs that previously produced silently wrong results. Any caller that fed near-vertical data to TLS and relied on the (incorrect) output will now receive an error instead.

## Post-Release Verification

- No regression against the existing test suite; CI passing is sufficient.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [ ] Design decisions documented in ADR (if applicable)
- [ ] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
