### PR TITLE
ci: add test hooks to pre-commit and Rust tests step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
               - 'rust-toolchain.toml'
               - 'uv.lock'
 
-      - name: Install uv
+      - name: Set up Python (uv)
         if: steps.filter.outputs.code == 'true'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -66,8 +66,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         # automatically reads rust-toolchain.toml to set up the toolchain
 
-      # Set up dependencies for Linux (Ubuntu)
-      - name: Setup Ubuntu dependencies
+      # Set up Rust build dependencies for Linux (Ubuntu)
+      - name: Set up Rust build dependencies (Ubuntu)
         if: steps.filter.outputs.code == 'true' && matrix.os == 'ubuntu-latest'
         run: |
           if command -v cmake &> /dev/null; then
@@ -78,8 +78,8 @@ jobs:
             sudo apt-get install -y cmake
           fi
 
-      # Set up dependencies for macOS
-      - name: Setup macOS dependencies
+      # Set up Rust build dependencies for macOS
+      - name: Set up Rust build dependencies (macOS)
         if: steps.filter.outputs.code == 'true' && matrix.os == 'macos-latest'
         run: |
           if command -v cmake &> /dev/null; then
@@ -89,8 +89,8 @@ jobs:
             brew install cmake
           fi
 
-      # Set up dependencies for Windows
-      - name: Setup Windows dependencies
+      # Set up Rust build dependencies for Windows
+      - name: Set up Rust build dependencies (Windows)
         if: steps.filter.outputs.code == 'true' && matrix.os == 'windows-latest'
         run: |
           if (Get-Command cmake -ErrorAction SilentlyContinue) {
@@ -100,8 +100,8 @@ jobs:
             choco install cmake -y
           }
 
-      # Sync dependencies
-      - name: Install dependencies
+      # Sync Python dependencies
+      - name: Install Python dependencies
         if: steps.filter.outputs.code == 'true'
         shell: bash
         run: |
@@ -113,29 +113,41 @@ jobs:
           # Sync dependencies from pyproject.toml (including main and dev dependencies)
           uv sync --frozen
 
-      # Lint and format checks
-      - name: Run lint and format checks
+      # Rust lint and format checks
+      - name: Lint and format Rust
         if: steps.filter.outputs.code == 'true'
         shell: bash
         run: |
-          echo "Running lint and format checks..."
-
-          # Python lint and format checks
-          echo "Checking Python code with ruff..."
-          uv run ruff check
-          uv run ruff format --check
-
-          # Rust format and lint checks
           echo "Checking Rust code formatting..."
           cargo fmt --all --check
 
           echo "Running Rust clippy..."
           cargo clippy --all-targets --all-features -- -D warnings
 
-          echo "All lint and format checks passed!"
+          echo "Rust lint and format checks passed!"
 
-      # Build and install
-      - name: Build wheels and install
+      # Python lint and format checks
+      - name: Lint and format Python
+        if: steps.filter.outputs.code == 'true'
+        shell: bash
+        run: |
+          echo "Checking Python code with ruff..."
+          uv run ruff check
+          uv run ruff format --check
+
+          echo "Python lint and format checks passed!"
+
+      # Run Rust unit tests
+      - name: Run Rust tests
+        if: steps.filter.outputs.code == 'true'
+        shell: bash
+        run: |
+          echo "Running Rust unit tests..."
+          cargo test
+          echo "Rust tests passed!"
+
+      # Build and install Python package
+      - name: Build and install Python wheels
         if: steps.filter.outputs.code == 'true'
         shell: bash
         run: |
@@ -158,15 +170,15 @@ jobs:
           uv run python -c "import sys; print('Python module paths:'); [print(p) for p in sys.path]"
           uv run python -c "import rustgression; print('Rustgression module location:', rustgression.__file__)"
 
-      # Test package import
-      - name: Test import
+      # Test Python package import
+      - name: Test Python package import
         if: steps.filter.outputs.code == 'true'
         shell: bash
         run: |
           uv run python scripts/test-import-operation.py
 
-      # Run tests
-      - name: Run tests
+      # Run Python tests
+      - name: Run Python tests
         if: steps.filter.outputs.code == 'true'
         shell: bash
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,9 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=500]
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
-    hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
-
   - repo: local
     hooks:
+      # Rust
       - id: rust-fmt
         name: rust fmt
         entry: cargo fmt
@@ -33,3 +27,30 @@ repos:
         files: \.rs$
         pass_filenames: false
         args: [--all-targets, --all-features, --, -D, warnings]
+      - id: rust-test
+        name: rust test
+        entry: cargo test
+        language: system
+        files: \.rs$
+        pass_filenames: false
+
+      # Python
+      - id: python-lint
+        name: python lint
+        entry: uv run ruff check
+        language: system
+        files: \.py$
+        pass_filenames: false
+        args: [--fix]
+      - id: python-format
+        name: python format
+        entry: uv run ruff format
+        language: system
+        files: \.py$
+        pass_filenames: false
+      - id: python-test
+        name: python test
+        entry: uv run pytest
+        language: system
+        files: \.py$
+        pass_filenames: false


### PR DESCRIPTION
<!-- # ci: add test hooks to pre-commit and Rust tests step to CI -->

## Related URLs

- N/A

## [Required] Overview

Pre-commit hooks enforced formatting and linting for both Rust and Python, but never ran tests — a commit could pass all hooks while breaking the test suite. Similarly, CI ran Python tests (`pytest`) but had no equivalent step for Rust unit tests (`cargo test`), leaving Rust-side regressions undetected until a wheel build failure.

This PR closes both gaps:

- Pre-commit now runs `cargo test` on `.rs` changes and `pytest` on `.py` changes, in addition to the existing lint/format hooks.
- CI now runs `cargo test` as a dedicated step between lint/format checks and the wheel build, so Rust unit failures are caught early and clearly surfaced.

As a related tidy, the `astral-sh/ruff-pre-commit` remote hook is replaced with equivalent local hooks (`python-lint`, `python-format`), making all language-specific hooks consistent in style. CI step names are also updated to indicate which language each step targets (Rust or Python).

## [Required] Release

- Release date
  - Anytime
- Release considerations
  - No API or behavior changes; CI and developer tooling only.

## Post-Release Verification

- CI passing on this PR is sufficient.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [ ] Design decisions documented in ADR (if applicable)
- [ ] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
