### PR TITLE
test(ols): add Longley dataset validation and tighten p-value assertions

### DIFF
--- a/src/regression/ols.rs
+++ b/src/regression/ols.rs
@@ -346,7 +346,7 @@ mod tests {
             for (name, t_value, df) in test_cases {
                 let p_val = calculate_p_value_exact(t_value, df);
                 assert!(
-                    (0.0..=2.0).contains(&p_val),
+                    (0.0..=1.0).contains(&p_val),
                     "{}: p-value out of range: {}",
                     name,
                     p_val

--- a/src/regression/utils/statistics.rs
+++ b/src/regression/utils/statistics.rs
@@ -216,7 +216,7 @@ mod tests {
             for (t_value, df) in test_cases {
                 let p_val = calculate_p_value_exact(t_value, df);
                 assert!(
-                    (0.0..=2.0).contains(&p_val),
+                    (0.0..=1.0).contains(&p_val),
                     "p-value out of range: {}",
                     p_val
                 );
@@ -228,7 +228,7 @@ mod tests {
             // Test with very small or invalid degrees of freedom
             let p_val = calculate_p_value_exact(1.0, 0.1);
             // Should return NaN for invalid df
-            assert!(p_val.is_nan() || (0.0..=2.0).contains(&p_val));
+            assert!(p_val.is_nan() || (0.0..=1.0).contains(&p_val));
         }
 
         #[test]

--- a/tests/test_ols_double_validation.py
+++ b/tests/test_ols_double_validation.py
@@ -40,6 +40,58 @@ def high_condition_number_data():
     return x, y
 
 
+@pytest.fixture
+def longley_data():
+    """Longley dataset (J. W. Longley, 1967).
+
+    A classic stress fixture for regression solvers due to its large absolute
+    scale. Used as the gold-standard validation dataset in statsmodels' TestOLS.
+    """
+    x = np.array(
+        [
+            1947,
+            1948,
+            1949,
+            1950,
+            1951,
+            1952,
+            1953,
+            1954,
+            1955,
+            1956,
+            1957,
+            1958,
+            1959,
+            1960,
+            1961,
+            1962,
+        ],
+        dtype=float,
+    )
+    y = np.array(
+        [
+            60323,
+            61122,
+            60171,
+            61187,
+            63221,
+            63639,
+            64989,
+            63761,
+            66019,
+            67857,
+            68169,
+            66513,
+            68655,
+            69564,
+            69331,
+            70551,
+        ],
+        dtype=float,
+    )
+    return x, y
+
+
 class TestOlsDoubleValidation:
     """Double-Validation tests comparing OLS outputs against scipy.stats.linregress."""
 
@@ -80,6 +132,15 @@ class TestOlsDoubleValidation:
         self, high_condition_number_data
     ):
         x, y = high_condition_number_data
+        ref_slope, ref_intercept, ref_r_value, _, _ = stats.linregress(x, y)
+        ols = OlsRegressor(x, y)
+
+        assert abs(ols.slope() - ref_slope) < 1e-6
+        assert abs(ols.intercept() - ref_intercept) < 1e-6
+        assert abs(ols.r_value() - ref_r_value) < 1e-6
+
+    def test_ols_matches_scipy_on_longley_dataset(self, longley_data):
+        x, y = longley_data
         ref_slope, ref_intercept, ref_r_value, _, _ = stats.linregress(x, y)
         ols = OlsRegressor(x, y)
 


### PR DESCRIPTION
<!-- # test(ols): add Longley dataset validation and tighten p-value assertions -->

## Related URLs

- Closes <https://github.com/connect0459/rustgression/issues/149>

## [Required] Overview

Follow-up to <https://github.com/connect0459/rustgression/issues/148> . Two test quality issues identified during the regression implementation research remain:

- The p-value range assertions in the Rust test suite used an upper bound of 2.0, which is incorrect — a two-tailed p-value is always in [0, 1]. This loose bound would not catch an implementation error that produced p > 1.
- The OLS double-validation suite relied solely on synthetic data. The Longley dataset (J. W. Longley, 1967) is the gold-standard stress fixture used by statsmodels' `TestOLS`; its large absolute scale is specifically known to expose numerical instability in regression solvers, and was missing from our validation suite.

This PR adds the Longley fixture and corrects the p-value bounds.

## [Required] Release

- Release date
  - Anytime
- Release considerations
  - Test-only changes; no public API or behavior changes.

## Post-Release Verification

- No runtime verification needed beyond CI.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [ ] Design decisions documented in ADR (if applicable)
- [ ] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
