### PR TITLE
ci: set persist-credentials: false on actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Detect changed files to skip subsequent steps when no relevant files are modified
       - name: Detect changed files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check version consistency
         shell: bash
@@ -37,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -131,6 +134,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0


### PR DESCRIPTION
<!-- # ci: set persist-credentials: false on actions/checkout -->

## [Required] Overview

By default, `actions/checkout` persists the `GITHUB_TOKEN` in the local git config, making it accessible to all subsequent steps. Setting `persist-credentials: false` removes the token immediately after checkout, reducing the risk of unintended token exposure.

Applied to all `actions/checkout` steps in the CI and release workflows.

## [Required] Release

- Release date
  - Anytime after CI passes
- Release considerations
  - CI-only change; no code, version bump, or PyPI publish required.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] Coverage is maintained (target 80%+)

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
