### PR TITLE
ci: classify github-actions Dependabot updates as ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,7 @@ updates:
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 3
     labels:
+      - "ci"
       - "dependencies"
       - "github-actions"
     groups:
@@ -65,5 +66,5 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "chore"
+      prefix: "ci"
       include: "scope"


### PR DESCRIPTION
<!-- # ci: classify github-actions Dependabot updates as ci -->

## [Required] Overview

GitHub Actions dependency updates from Dependabot were committed under the `chore` prefix, which conflicts with our commit-convention type table that maps GitHub Actions / workflow changes to the `ci` type.

This PR reclassifies the `github-actions` ecosystem in `.github/dependabot.yml` to use the `ci` prefix, so that automated Actions bumps are categorized consistently with manual CI changes. The `ci` label is also added to github-actions Dependabot PRs, alongside the existing `dependencies` and `github-actions` labels. No behavior change to the CI workflows themselves.

## [Required] Release

- Release date: Anytime (CI configuration change, no code or version bump required)
- Release considerations: None

## Areas That Need Special Review Attention

- The `ci` label must exist in the repository for Dependabot to apply it (already created).
- Verify that the next github-actions Dependabot PR is titled `ci(deps): ...`.
