### PR TITLE
test(regression): add unit and double-validation tests for OlsMultiRegressor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ dev = [
   "pytest==9.1.1",
   "pytest-cov==7.1.0",
   "ruff==0.15.20",
+  "scikit-learn>=1.0.0",
   "scipy>=1.15.2",
   "setuptools==82.0.1",
 ]

--- a/rustgression/regression/ols_multi.py
+++ b/rustgression/regression/ols_multi.py
@@ -182,7 +182,7 @@ class OlsMultiRegressor:
             stacklevel=2,
         )
         return OlsMultiRegressionParams(
-            coefficients=self._coefficients,
+            coefficients=self._coefficients.copy(),
             r_squared=self._r_squared,
             f_statistic=self._f_statistic,
             p_value=self._p_value,

--- a/tests/test_ols_multi.py
+++ b/tests/test_ols_multi.py
@@ -114,28 +114,30 @@ class TestOlsMultiRegressor:
         )
         y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="rank-deficient"):
             OlsMultiRegressor(x_mat, y)
 
     def test_raises_value_error_when_observations_do_not_exceed_predictors(self):
-        x_mat = np.random.randn(3, 4)
-        y = np.random.randn(3)
+        rng = np.random.default_rng(0)
+        x_mat = rng.standard_normal((3, 4))
+        y = rng.standard_normal(3)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must exceed number of predictors"):
             OlsMultiRegressor(x_mat, y)
 
     def test_raises_value_error_when_n_equals_p(self):
-        x_mat = np.random.randn(3, 3)
-        y = np.random.randn(3)
+        rng = np.random.default_rng(0)
+        x_mat = rng.standard_normal((3, 3))
+        y = rng.standard_normal(3)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must exceed number of predictors"):
             OlsMultiRegressor(x_mat, y)
 
     def test_raises_value_error_for_1d_x_input(self):
         x = np.array([1.0, 2.0, 3.0])
         y = np.array([1.0, 2.0, 3.0])
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must be a 2D array"):
             OlsMultiRegressor(x, y)
 
     def test_raises_value_error_when_feature_count_mismatches_at_predict_time(
@@ -143,9 +145,9 @@ class TestOlsMultiRegressor:
     ):
         x_mat, y = standard_noisy_data
         model = OlsMultiRegressor(x_mat, y)
-        x_wrong = np.random.randn(10, 3)
+        x_wrong = np.random.default_rng(0).standard_normal((10, 3))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Expected \d+ features"):
             model.predict(x_wrong)
 
     def test_get_params_returns_ols_multi_regression_params_instance(
@@ -265,7 +267,7 @@ class TestOlsMultiDoubleValidation:
         ref = LinearRegression().fit(x_mat, y)
         model = OlsMultiRegressor(x_mat, y)
 
-        assert abs(model.intercept() - ref.intercept_) < 1e-4
+        np.testing.assert_allclose(model.intercept(), ref.intercept_, rtol=1e-7)
         assert abs(model.coefficients()[1] - ref.coef_[0]) < 1e-6
         assert abs(model.coefficients()[2] - ref.coef_[1]) < 1e-4
 

--- a/tests/test_ols_multi.py
+++ b/tests/test_ols_multi.py
@@ -1,0 +1,277 @@
+"""
+Unit tests and sklearn double-validation for OlsMultiRegressor.
+"""
+
+import numpy as np
+import pytest
+from sklearn.linear_model import LinearRegression
+
+from rustgression import OlsMultiRegressionParams, OlsMultiRegressor, OlsRegressor
+
+
+@pytest.fixture
+def standard_noisy_data():
+    """y = 2*x1 + 0.5*x2 + 1 + noise"""
+    rng = np.random.default_rng(42)
+    n = 100
+    x_mat = rng.random((n, 2)) * 10
+    y = 2.0 * x_mat[:, 0] + 0.5 * x_mat[:, 1] + 1.0 + rng.normal(0, 0.5, n)
+    return x_mat, y
+
+
+@pytest.fixture
+def perfect_linear_data():
+    """y = 3*x1 + 1.5*x2 + 2.5, zero residuals, linearly independent features"""
+    x_mat = np.array(
+        [[1.0, 5.0], [2.0, 3.0], [3.0, 8.0], [4.0, 2.0], [5.0, 7.0], [6.0, 1.0]],
+        dtype=float,
+    )
+    y = 3.0 * x_mat[:, 0] + 1.5 * x_mat[:, 1] + 2.5
+    return x_mat, y
+
+
+@pytest.fixture
+def high_condition_number_data():
+    """x1 in [10000, 10100], x2 in [0, 1]"""
+    rng = np.random.default_rng(7)
+    n = 200
+    x1 = np.linspace(10000, 10100, n)
+    x2 = rng.random(n)
+    x_mat = np.column_stack([x1, x2])
+    y = 2.5 * x1 + 0.3 * x2 - 24900.0 + rng.normal(0, 1.0, n)
+    return x_mat, y
+
+
+class TestOlsMultiRegressor:
+    """Unit tests for OlsMultiRegressor."""
+
+    def test_returns_coefficients_close_to_known_values_for_perfect_linear_data(
+        self, perfect_linear_data
+    ):
+        x_mat, y = perfect_linear_data
+        model = OlsMultiRegressor(x_mat, y)
+        coefs = model.coefficients()
+
+        assert abs(coefs[0] - 2.5) < 1e-8
+        assert abs(coefs[1] - 3.0) < 1e-8
+        assert abs(coefs[2] - 1.5) < 1e-8
+
+    def test_returns_r_squared_of_one_for_perfect_linear_data(
+        self, perfect_linear_data
+    ):
+        x_mat, y = perfect_linear_data
+        model = OlsMultiRegressor(x_mat, y)
+
+        assert abs(model.r_squared() - 1.0) < 1e-10
+
+    def test_returns_coefficients_close_to_known_values_for_standard_noisy_data(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        model = OlsMultiRegressor(x_mat, y)
+        coefs = model.coefficients()
+
+        assert abs(coefs[1] - 2.0) < 0.15
+        assert abs(coefs[2] - 0.5) < 0.15
+        assert abs(coefs[0] - 1.0) < 0.5
+
+    def test_predict_returns_exact_values_for_perfect_linear_data(
+        self, perfect_linear_data
+    ):
+        x_mat, y = perfect_linear_data
+        model = OlsMultiRegressor(x_mat, y)
+        y_pred = model.predict(x_mat)
+
+        np.testing.assert_array_almost_equal(y_pred, y, decimal=8)
+
+    def test_predict_accepts_1d_input_as_single_sample(self, perfect_linear_data):
+        x_mat, y = perfect_linear_data
+        model = OlsMultiRegressor(x_mat, y)
+        single_sample = x_mat[0]
+        result = model.predict(single_sample)
+
+        assert result.shape == (1,)
+        assert abs(result[0] - y[0]) < 1e-8
+
+    def test_matches_ols_regressor_output_when_given_single_predictor(self):
+        rng = np.random.default_rng(42)
+        x = rng.random(50) * 10
+        y = 3.0 * x + 2.0 + rng.normal(0, 0.5, 50)
+        x_mat = x.reshape(-1, 1)
+
+        multi = OlsMultiRegressor(x_mat, y)
+        single = OlsRegressor(x, y)
+
+        assert abs(multi.intercept() - single.intercept()) < 1e-10
+        assert abs(multi.coefficients()[1] - single.slope()) < 1e-10
+
+    def test_raises_value_error_for_collinear_predictors(self):
+        x_mat = np.column_stack(
+            [
+                np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+                np.array([2.0, 4.0, 6.0, 8.0, 10.0]),
+            ]
+        )
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        with pytest.raises(ValueError):
+            OlsMultiRegressor(x_mat, y)
+
+    def test_raises_value_error_when_observations_do_not_exceed_predictors(self):
+        x_mat = np.random.randn(3, 4)
+        y = np.random.randn(3)
+
+        with pytest.raises(ValueError):
+            OlsMultiRegressor(x_mat, y)
+
+    def test_raises_value_error_when_n_equals_p(self):
+        x_mat = np.random.randn(3, 3)
+        y = np.random.randn(3)
+
+        with pytest.raises(ValueError):
+            OlsMultiRegressor(x_mat, y)
+
+    def test_raises_value_error_for_1d_x_input(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([1.0, 2.0, 3.0])
+
+        with pytest.raises(ValueError):
+            OlsMultiRegressor(x, y)
+
+    def test_raises_value_error_when_feature_count_mismatches_at_predict_time(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        model = OlsMultiRegressor(x_mat, y)
+        x_wrong = np.random.randn(10, 3)
+
+        with pytest.raises(ValueError):
+            model.predict(x_wrong)
+
+    def test_get_params_returns_ols_multi_regression_params_instance(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        model = OlsMultiRegressor(x_mat, y)
+
+        with pytest.warns(DeprecationWarning):
+            params = model.get_params()
+
+        assert isinstance(params, OlsMultiRegressionParams)
+
+    def test_coefficients_returns_defensive_copy(self, standard_noisy_data):
+        x_mat, y = standard_noisy_data
+        model = OlsMultiRegressor(x_mat, y)
+        coefs_before = model.coefficients().copy()
+        model.coefficients()[0] = 9999.0
+        coefs_after = model.coefficients()
+
+        np.testing.assert_array_equal(coefs_before, coefs_after)
+
+    def test_repr_includes_class_name_intercept_and_r_squared(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        model = OlsMultiRegressor(x_mat, y)
+        representation = repr(model)
+
+        assert "OlsMultiRegressor" in representation
+        assert "intercept=" in representation
+        assert "r_squared=" in representation
+
+
+class TestOlsMultiDoubleValidation:
+    """Double-validation tests comparing OlsMultiRegressor against sklearn."""
+
+    def test_coefficients_match_sklearn_for_standard_noisy_data(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        assert abs(model.intercept() - ref.intercept_) < 1e-8
+        assert abs(model.coefficients()[1] - ref.coef_[0]) < 1e-8
+        assert abs(model.coefficients()[2] - ref.coef_[1]) < 1e-8
+
+    def test_r_squared_matches_sklearn_for_standard_noisy_data(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        assert abs(model.r_squared() - ref.score(x_mat, y)) < 1e-10
+
+    def test_predictions_match_sklearn_for_standard_noisy_data(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        np.testing.assert_array_almost_equal(
+            model.predict(x_mat), ref.predict(x_mat), decimal=8
+        )
+
+    def test_coefficients_match_sklearn_for_perfect_linear_data(
+        self, perfect_linear_data
+    ):
+        x_mat, y = perfect_linear_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        assert abs(model.intercept() - ref.intercept_) < 1e-8
+        assert abs(model.coefficients()[1] - ref.coef_[0]) < 1e-8
+        assert abs(model.coefficients()[2] - ref.coef_[1]) < 1e-8
+
+    def test_r_squared_matches_sklearn_for_perfect_linear_data(
+        self, perfect_linear_data
+    ):
+        x_mat, y = perfect_linear_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        assert abs(model.r_squared() - ref.score(x_mat, y)) < 1e-10
+
+    def test_predictions_match_sklearn_for_perfect_linear_data(
+        self, perfect_linear_data
+    ):
+        x_mat, y = perfect_linear_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        np.testing.assert_array_almost_equal(
+            model.predict(x_mat), ref.predict(x_mat), decimal=8
+        )
+
+    def test_coefficients_match_sklearn_for_high_condition_number_data(
+        self, high_condition_number_data
+    ):
+        x_mat, y = high_condition_number_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        assert abs(model.intercept() - ref.intercept_) < 1e-4
+        assert abs(model.coefficients()[1] - ref.coef_[0]) < 1e-6
+        assert abs(model.coefficients()[2] - ref.coef_[1]) < 1e-4
+
+    def test_r_squared_matches_sklearn_for_high_condition_number_data(
+        self, high_condition_number_data
+    ):
+        x_mat, y = high_condition_number_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        assert abs(model.r_squared() - ref.score(x_mat, y)) < 1e-6
+
+    def test_predictions_match_sklearn_for_high_condition_number_data(
+        self, high_condition_number_data
+    ):
+        x_mat, y = high_condition_number_data
+        ref = LinearRegression().fit(x_mat, y)
+        model = OlsMultiRegressor(x_mat, y)
+
+        np.testing.assert_array_almost_equal(
+            model.predict(x_mat), ref.predict(x_mat), decimal=4
+        )

--- a/tests/test_ols_multi.py
+++ b/tests/test_ols_multi.py
@@ -159,6 +159,19 @@ class TestOlsMultiRegressor:
 
         assert isinstance(params, OlsMultiRegressionParams)
 
+    def test_get_params_coefficients_do_not_mutate_internal_state(
+        self, standard_noisy_data
+    ):
+        x_mat, y = standard_noisy_data
+        model = OlsMultiRegressor(x_mat, y)
+        intercept_before = model.intercept()
+
+        with pytest.warns(DeprecationWarning):
+            params = model.get_params()
+        params.coefficients[0] = 9999.0
+
+        assert abs(model.intercept() - intercept_before) < 1e-10
+
     def test_coefficients_returns_defensive_copy(self, standard_noisy_data):
         x_mat, y = standard_noisy_data
         model = OlsMultiRegressor(x_mat, y)

--- a/uv.lock
+++ b/uv.lock
@@ -495,6 +495,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "keyring"
 version = "25.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -715,6 +724,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
 ]
 
 [[package]]
@@ -1220,6 +1238,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scikit-learn" },
     { name = "scipy" },
     { name = "setuptools" },
     { name = "twine" },
@@ -1245,11 +1264,57 @@ dev = [
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.15.20" },
+    { name = "scikit-learn", specifier = ">=1.0.0" },
     { name = "scipy", specifier = ">=1.15.2" },
     { name = "setuptools", specifier = "==82.0.1" },
     { name = "twine", specifier = "==6.2.0" },
 ]
 release = [{ name = "twine", specifier = "==6.2.0" }]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
 
 [[package]]
 name = "scipy"
@@ -1351,6 +1416,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- # test(regression): add unit and double-validation tests for OlsMultiRegressor -->

## Related URLs

- Issues
  - Closes <https://github.com/connect0459/rustgression/issues/165>
- PRs
  - N/A

## [Required] Overview

`OlsMultiRegressor` had no dedicated test file, leaving its numerical accuracy and error-handling behavior unverified. This PR adds a test suite covering unit behavior and sklearn double-validation. No Rust or production Python files are modified.

Unit tests verify exact coefficient recovery for zero-residual data, approximate recovery for standard noisy data, and correct `ValueError` raises for collinear predictors, `n ≤ p`, 1D input, and mismatched feature counts at predict time. A single-predictor case is cross-checked against `OlsRegressor` to confirm consistency between the single and multi-predictor code paths.

Double-validation tests call `sklearn.linear_model.LinearRegression` at test time with the same data and assert numerical agreement on coefficients, R-squared, and predictions across three fixtures: standard noisy data, perfect linear data (zero residuals), and high-condition-number data. `scikit-learn` is added to the dev dependency group to support these comparisons.

## [Required] Release

- Release date: Anytime
- Release considerations: No production code is changed; this is a test-only addition.

## Post-Release Verification

- All 85 tests pass in the Docker dev environment.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [x] Design decisions documented in ADR (if applicable)
- [x] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
