### PR TITLE
fix(tls): correct TLS standard error using Deming regression variance estimator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
         shell: bash
         run: |
           echo "Running Rust unit tests..."
+          export PYO3_PYTHON="$(uv run python -c 'import sys; print(sys.executable)')"
+          echo "PYO3_PYTHON=$PYO3_PYTHON"
           cargo test
           echo "Rust tests passed!"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,6 @@ jobs:
         shell: bash
         run: |
           echo "Running Rust unit tests..."
-          export PYO3_PYTHON="$(uv run python -c 'import sys; print(sys.executable)')"
-          echo "PYO3_PYTHON=$PYO3_PYTHON"
           cargo test
           echo "Rust tests passed!"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,11 @@ license = "MIT"
 name = "rustgression"
 crate-type = ["cdylib"]
 
+[features]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
-pyo3 = { version = "0.26", features = ["extension-module"] }
+pyo3 = { version = "0.26" }
 numpy = "0.26"
 nalgebra = "0.35"
 statrs = "0.18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ build-backend = "maturin"
 
 [tool.maturin]
 python-source = "."
-features = ["pyo3/extension-module"]
+features = ["extension-module"]
 bindings = "pyo3"
 
 [tool.pytest.ini_options]

--- a/rustgression/regression/tls.py
+++ b/rustgression/regression/tls.py
@@ -19,12 +19,10 @@ class TlsRegressor(BaseRegressor[TlsRegressionParams]):
     variables.
 
     Note on goodness-of-fit metrics: residuals() returns *vertical* residuals
-    (y - predict(x)), not orthogonal residuals, consistent with the
-    vertical-residual inference used for p_value() and stderr().
-    Consequently, r_squared() returns the squared Pearson correlation
-    coefficient and does NOT satisfy r_squared() == 1 - SS_res / SS_tot
-    for TLS; combining both metrics for a classical R² check will not
-    produce consistent results.
+    (y - predict(x)), not orthogonal residuals.  r_squared() returns the
+    squared Pearson correlation coefficient and does NOT satisfy
+    r_squared() == 1 - SS_res / SS_tot for TLS; combining both metrics for
+    a classical R² check will not produce consistent results.
 
     """
 
@@ -73,8 +71,9 @@ class TlsRegressor(BaseRegressor[TlsRegressionParams]):
     def p_value(self) -> float:
         """Return the two-tailed p-value for the slope.
 
-        Computed via a t-test with n-2 degrees of freedom, assuming equal
-        measurement error variance (λ=1) in both x and y.
+        Computed via a t-test with n-2 degrees of freedom using the Deming
+        (orthogonal, λ=1) slope variance estimator, which matches equal-weight
+        ODR (scipy.odr / odrpack).
 
         Returns
         -------
@@ -86,9 +85,10 @@ class TlsRegressor(BaseRegressor[TlsRegressionParams]):
     def stderr(self) -> float:
         """Return the standard error of the slope.
 
-        Derived from vertical residuals, which is equivalent to
-        orthogonal-residual inference under equal measurement error
-        variance (λ=1).
+        Uses the Deming (orthogonal, λ=1) variance estimator: the effective
+        sum of squares Sxx* = Σ(xi* - x̄)², where xi* is the foot of the
+        perpendicular from each observed point to the TLS line.  This matches
+        equal-weight ODR (scipy.odr / odrpack) to within ~1%.
 
         Returns
         -------

--- a/src/regression/ols.rs
+++ b/src/regression/ols.rs
@@ -1,7 +1,7 @@
 #![allow(unsafe_op_in_unsafe_fn)] // PyO3 internal operations require unsafe
 
 use crate::regression::utils::{
-    calculate_p_value_exact, kahan_sum, safe_divide, validate_finite_array,
+    calculate_slope_inference, kahan_sum, safe_divide, validate_finite_array,
 };
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1};
 use pyo3::prelude::*;
@@ -66,7 +66,7 @@ pub fn calculate_ols_regression<'py>(
     let ss_res = calculate_residual_sum_of_squares(&x_array, &y_array, slope, intercept);
 
     let (stderr, p_value, intercept_stderr) =
-        calculate_standard_errors(n, ss_xx, ss_res, slope, x_mean);
+        calculate_slope_inference(n, ss_xx, ss_res, slope, x_mean);
 
     // Calculate predicted values
     let y_pred: Array1Ref = x_array.mapv(|v| slope * v + intercept);
@@ -138,42 +138,6 @@ fn calculate_residual_sum_of_squares(
         residual_terms.push(diff * diff);
     }
     kahan_sum(&residual_terms)
-}
-
-/// Calculate standard error, p-value, and intercept standard error
-fn calculate_standard_errors(
-    n: f64,
-    ss_xx: f64,
-    ss_res: f64,
-    slope: f64,
-    x_mean: f64,
-) -> (f64, f64, f64) {
-    let stderr = if n > 2.0 && ss_xx > f64::EPSILON {
-        let sd_res = (ss_res / (n - 2.0)).sqrt();
-        if sd_res.is_finite() && ss_xx > 0.0 {
-            safe_divide(sd_res, ss_xx.sqrt(), "standard error calculation").unwrap_or(f64::NAN)
-        } else {
-            f64::NAN
-        }
-    } else {
-        f64::NAN
-    };
-
-    let p_value = if n > 2.0 && stderr != 0.0 {
-        let t_stat = slope.abs() / stderr;
-        calculate_p_value_exact(t_stat, n - 2.0)
-    } else {
-        f64::NAN
-    };
-
-    let intercept_stderr = if n > 2.0 && ss_xx > 0.0 {
-        let sd_res = (ss_res / (n - 2.0)).sqrt();
-        sd_res * ((1.0 / n) + (x_mean * x_mean) / ss_xx).sqrt()
-    } else {
-        f64::NAN
-    };
-
-    (stderr, p_value, intercept_stderr)
 }
 
 #[cfg(test)]
@@ -325,7 +289,7 @@ mod tests {
     }
 
     mod calculate_p_value_exact {
-        use super::*;
+        use crate::regression::utils::statistics::calculate_p_value_exact;
 
         #[test]
         fn returns_valid_p_value_for_large_degrees_of_freedom() {

--- a/src/regression/tls.rs
+++ b/src/regression/tls.rs
@@ -212,11 +212,18 @@ fn calculate_slope_with_sign_correction(
     Ok((slope, intercept))
 }
 
-/// Compute standard error, p-value, and intercept standard error for TLS.
+/// Compute standard error, p-value, and intercept standard error for TLS
+/// using the Deming (orthogonal, λ=1) regression variance estimator.
 ///
-/// Uses vertical residuals with the OLS-equivalent formula, which is
-/// mathematically identical to orthogonal-residual inference when equal
-/// measurement error variance (λ=1) is assumed.
+/// For equal measurement error variance (λ=1), the ODR covariance matrix
+/// is s² * (Xstar'Xstar)^{-1}, where:
+///   - xi* = xi + β·ri/(1+β²)  (foot of perpendicular from xi to the TLS line)
+///   - ri = yi - β·xi - α       (vertical residual)
+///   - s² = Σri² / (n-2)        (residual variance)
+///   - Sxx* = Σ(xi* - x̄)²     (x̄* = x̄ because Σri = 0 for TLS with intercept)
+///
+/// This yields slope_stderr = s / √Sxx* and intercept_stderr = s·√(1/n + x̄²/Sxx*),
+/// matching scipy.odr with equal weights.
 fn calculate_tls_inference(
     x_array: &Array1Ref,
     y_array: &Array1Ref,
@@ -225,24 +232,26 @@ fn calculate_tls_inference(
     x_mean: f64,
 ) -> (f64, f64, f64) {
     let n = x_array.len() as f64;
+    let one_plus_slope_sq = 1.0 + slope * slope;
 
     let mut res_terms = Vec::with_capacity(x_array.len());
-    let mut ss_x_terms = Vec::with_capacity(x_array.len());
+    let mut ss_x_star_terms = Vec::with_capacity(x_array.len());
     for i in 0..x_array.len() {
-        let diff = y_array[i] - slope * x_array[i] - intercept;
-        res_terms.push(diff * diff);
-        let dx = x_array[i] - x_mean;
-        ss_x_terms.push(dx * dx);
+        let ri = y_array[i] - slope * x_array[i] - intercept;
+        res_terms.push(ri * ri);
+        let x_star = x_array[i] + slope * ri / one_plus_slope_sq;
+        let dx_star = x_star - x_mean;
+        ss_x_star_terms.push(dx_star * dx_star);
     }
     let ss_res = kahan_sum(&res_terms);
-    let ss_xx = kahan_sum(&ss_x_terms);
+    let ss_x_star = kahan_sum(&ss_x_star_terms);
 
-    if n <= 2.0 || ss_xx <= f64::EPSILON {
+    if n <= 2.0 || ss_x_star <= f64::EPSILON {
         return (f64::NAN, f64::NAN, f64::NAN);
     }
 
     let s = (ss_res / (n - 2.0)).sqrt();
-    let stderr = s / ss_xx.sqrt();
+    let stderr = s / ss_x_star.sqrt();
 
     let p_value = if stderr > 0.0 && stderr.is_finite() {
         calculate_p_value_exact(slope.abs() / stderr, n - 2.0)
@@ -250,7 +259,7 @@ fn calculate_tls_inference(
         f64::NAN
     };
 
-    let intercept_stderr = s * (1.0 / n + x_mean * x_mean / ss_xx).sqrt();
+    let intercept_stderr = s * (1.0 / n + x_mean * x_mean / ss_x_star).sqrt();
 
     (stderr, p_value, intercept_stderr)
 }
@@ -672,6 +681,89 @@ mod tests {
                 let _ = result.intercept;
                 let _ = result.r_value;
             }
+        }
+    }
+
+    mod deming_inference {
+        use super::*;
+
+        fn make_array(v: Vec<f64>) -> Array1Ref {
+            numpy::ndarray::Array1::from_vec(v)
+        }
+
+        #[test]
+        fn returns_nan_for_minimal_data() {
+            let x = make_array(vec![1.0, 2.0]);
+            let y = make_array(vec![2.0, 4.0]);
+            let slope = 2.0;
+            let intercept = 0.0;
+            let x_mean = 1.5;
+
+            let (stderr, p_value, intercept_stderr) =
+                calculate_tls_inference(&x, &y, slope, intercept, x_mean);
+
+            assert!(stderr.is_nan(), "stderr should be NaN for n=2");
+            assert!(p_value.is_nan(), "p_value should be NaN for n=2");
+            assert!(
+                intercept_stderr.is_nan(),
+                "intercept_stderr should be NaN for n=2"
+            );
+        }
+
+        #[test]
+        fn returns_finite_values_for_valid_noisy_data() {
+            let x = make_array(vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+            let y = make_array(vec![0.3, 1.1, 1.8, 3.2, 3.9, 5.1, 6.2, 6.8, 8.1, 9.2]);
+            let x_mean = x.mean().unwrap();
+
+            let tls = perform_tls(x.as_slice().unwrap(), y.as_slice().unwrap());
+            let (stderr, p_value, intercept_stderr) =
+                calculate_tls_inference(&x, &y, tls.slope, tls.intercept, x_mean);
+
+            assert!(stderr.is_finite(), "stderr should be finite");
+            assert!(p_value.is_finite(), "p_value should be finite");
+            assert!(
+                intercept_stderr.is_finite(),
+                "intercept_stderr should be finite"
+            );
+            assert!((0.0..=1.0).contains(&p_value), "p_value must be in [0, 1]");
+        }
+
+        #[test]
+        fn deming_stderr_exceeds_ols_formula_for_steep_slope_with_x_noise() {
+            // y = 10x + noise, noise in both x and y.
+            // TLS β > OLS β (attenuation correction), so Sxx* < Sxx,
+            // and Deming stderr > OLS-formula stderr.
+            let x_obs = make_array(vec![0.5, 1.8, 1.9, 3.3, 4.1, 5.2, 6.3, 7.1, 7.9, 9.4]);
+            let y_obs = make_array(vec![
+                1.0, 18.0, 21.0, 29.0, 42.0, 51.0, 63.0, 69.0, 81.0, 92.0,
+            ]);
+            let x_mean = x_obs.mean().unwrap();
+            let n = x_obs.len() as f64;
+
+            let tls = perform_tls(x_obs.as_slice().unwrap(), y_obs.as_slice().unwrap());
+            let (deming_stderr, _, _) =
+                calculate_tls_inference(&x_obs, &y_obs, tls.slope, tls.intercept, x_mean);
+
+            // Compute OLS formula stderr for comparison
+            let ss_res: f64 = x_obs
+                .iter()
+                .zip(y_obs.iter())
+                .map(|(&xi, &yi)| {
+                    let r = yi - tls.slope * xi - tls.intercept;
+                    r * r
+                })
+                .sum();
+            let ss_xx: f64 = x_obs.iter().map(|&xi| (xi - x_mean).powi(2)).sum();
+            let s = (ss_res / (n - 2.0)).sqrt();
+            let ols_formula_stderr = s / ss_xx.sqrt();
+
+            assert!(
+                deming_stderr > ols_formula_stderr,
+                "Deming stderr ({:.4}) should exceed OLS-formula stderr ({:.4}) for steep slopes with x noise",
+                deming_stderr,
+                ols_formula_stderr
+            );
         }
     }
 

--- a/src/regression/tls.rs
+++ b/src/regression/tls.rs
@@ -712,9 +712,13 @@ mod tests {
 
         #[test]
         fn stderr_is_larger_than_vertical_residual_approximation_when_x_has_measurement_noise() {
-            let x_obs = make_array(vec![0.5, 1.8, 1.9, 3.3, 4.1, 5.2, 6.3, 7.1, 7.9, 9.4]);
+            // x_obs has large noise relative to the true x spacing (noise ≈ 1.5 per unit),
+            // so TLS attenuation-correction is strong and the ratio is well above 1.0.
+            let x_obs = make_array(vec![
+                2.5, 0.2, 4.2, 2.6, 6.6, 4.9, 8.9, 6.7, 10.7, 8.5, 12.2, 10.2,
+            ]);
             let y_obs = make_array(vec![
-                1.0, 18.0, 21.0, 29.0, 42.0, 51.0, 63.0, 69.0, 81.0, 92.0,
+                9.0, 21.0, 29.0, 41.0, 51.0, 59.0, 71.0, 80.0, 89.0, 101.0, 109.0, 121.0,
             ]);
             let x_mean = x_obs.mean().unwrap();
             let n = x_obs.len() as f64;
@@ -735,9 +739,11 @@ mod tests {
             let s = (ss_res / (n - 2.0)).sqrt();
             let vertical_residual_stderr = s / ss_xx.sqrt();
 
+            let ratio = tls_stderr / vertical_residual_stderr;
             assert!(
-                tls_stderr > vertical_residual_stderr,
-                "TLS stderr ({:.4}) should exceed vertical-residual stderr ({:.4})",
+                ratio > 1.05,
+                "TLS stderr ratio ({:.3}) should exceed 1.05; tls={:.4}, vr={:.4}",
+                ratio,
                 tls_stderr,
                 vertical_residual_stderr
             );

--- a/src/regression/tls.rs
+++ b/src/regression/tls.rs
@@ -1,7 +1,7 @@
 #![allow(unsafe_op_in_unsafe_fn)] // PyO3 internal operations require unsafe
 #[allow(unused_imports)] // kahan_sum and Array1 are used in tests
 use crate::regression::utils::{
-    calculate_p_value_exact, compute_r_value, kahan_sum, safe_divide, validate_finite_array,
+    calculate_slope_inference, compute_r_value, kahan_sum, safe_divide, validate_finite_array,
 };
 use nalgebra::{DMatrix, SVD};
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1};
@@ -215,15 +215,11 @@ fn calculate_slope_with_sign_correction(
 /// Compute standard error, p-value, and intercept standard error for TLS
 /// using the Deming (orthogonal, λ=1) regression variance estimator.
 ///
-/// For equal measurement error variance (λ=1), the ODR covariance matrix
-/// is s² * (Xstar'Xstar)^{-1}, where:
-///   - xi* = xi + β·ri/(1+β²)  (foot of perpendicular from xi to the TLS line)
-///   - ri = yi - β·xi - α       (vertical residual)
-///   - s² = Σri² / (n-2)        (residual variance)
-///   - Sxx* = Σ(xi* - x̄)²     (x̄* = x̄ because Σri = 0 for TLS with intercept)
-///
-/// This yields slope_stderr = s / √Sxx* and intercept_stderr = s·√(1/n + x̄²/Sxx*),
-/// matching scipy.odr with equal weights.
+/// Computes xi* = xi + β·ri/(1+β²) (foot of perpendicular from each observed
+/// point to the TLS line) and Sxx* = Σ(xi* - x̄)².  Because Σri = 0 at the
+/// TLS solution, x̄* = x̄ exactly.  The resulting Sxx* is passed to the shared
+/// `calculate_slope_inference` helper, which applies the same robustness guards
+/// used by OLS.
 fn calculate_tls_inference(
     x_array: &Array1Ref,
     y_array: &Array1Ref,
@@ -246,22 +242,7 @@ fn calculate_tls_inference(
     let ss_res = kahan_sum(&res_terms);
     let ss_x_star = kahan_sum(&ss_x_star_terms);
 
-    if n <= 2.0 || ss_x_star <= f64::EPSILON {
-        return (f64::NAN, f64::NAN, f64::NAN);
-    }
-
-    let s = (ss_res / (n - 2.0)).sqrt();
-    let stderr = s / ss_x_star.sqrt();
-
-    let p_value = if stderr > 0.0 && stderr.is_finite() {
-        calculate_p_value_exact(slope.abs() / stderr, n - 2.0)
-    } else {
-        f64::NAN
-    };
-
-    let intercept_stderr = s * (1.0 / n + x_mean * x_mean / ss_x_star).sqrt();
-
-    (stderr, p_value, intercept_stderr)
+    calculate_slope_inference(n, ss_x_star, ss_res, slope, x_mean)
 }
 
 #[cfg(test)]

--- a/src/regression/tls.rs
+++ b/src/regression/tls.rs
@@ -730,10 +730,7 @@ mod tests {
         }
 
         #[test]
-        fn deming_stderr_exceeds_ols_formula_for_steep_slope_with_x_noise() {
-            // y = 10x + noise, noise in both x and y.
-            // TLS β > OLS β (attenuation correction), so Sxx* < Sxx,
-            // and Deming stderr > OLS-formula stderr.
+        fn stderr_is_larger_than_vertical_residual_approximation_when_x_has_measurement_noise() {
             let x_obs = make_array(vec![0.5, 1.8, 1.9, 3.3, 4.1, 5.2, 6.3, 7.1, 7.9, 9.4]);
             let y_obs = make_array(vec![
                 1.0, 18.0, 21.0, 29.0, 42.0, 51.0, 63.0, 69.0, 81.0, 92.0,
@@ -742,10 +739,9 @@ mod tests {
             let n = x_obs.len() as f64;
 
             let tls = perform_tls(x_obs.as_slice().unwrap(), y_obs.as_slice().unwrap());
-            let (deming_stderr, _, _) =
+            let (tls_stderr, _, _) =
                 calculate_tls_inference(&x_obs, &y_obs, tls.slope, tls.intercept, x_mean);
 
-            // Compute OLS formula stderr for comparison
             let ss_res: f64 = x_obs
                 .iter()
                 .zip(y_obs.iter())
@@ -756,13 +752,13 @@ mod tests {
                 .sum();
             let ss_xx: f64 = x_obs.iter().map(|&xi| (xi - x_mean).powi(2)).sum();
             let s = (ss_res / (n - 2.0)).sqrt();
-            let ols_formula_stderr = s / ss_xx.sqrt();
+            let vertical_residual_stderr = s / ss_xx.sqrt();
 
             assert!(
-                deming_stderr > ols_formula_stderr,
-                "Deming stderr ({:.4}) should exceed OLS-formula stderr ({:.4}) for steep slopes with x noise",
-                deming_stderr,
-                ols_formula_stderr
+                tls_stderr > vertical_residual_stderr,
+                "TLS stderr ({:.4}) should exceed vertical-residual stderr ({:.4})",
+                tls_stderr,
+                vertical_residual_stderr
             );
         }
     }

--- a/src/regression/utils/mod.rs
+++ b/src/regression/utils/mod.rs
@@ -6,5 +6,5 @@ pub mod validation;
 
 // Re-export commonly used functions
 pub use math::kahan_sum;
-pub use statistics::{calculate_p_value_exact, compute_r_value};
+pub use statistics::{calculate_slope_inference, compute_r_value};
 pub use validation::{safe_divide, validate_finite_array};

--- a/src/regression/utils/statistics.rs
+++ b/src/regression/utils/statistics.rs
@@ -1,4 +1,5 @@
 use crate::regression::utils::math::kahan_sum;
+use crate::regression::utils::validation::safe_divide;
 use numpy::ndarray::Array1;
 use statrs::distribution::{ContinuousCDF, StudentsT};
 use std::f64;
@@ -68,6 +69,46 @@ pub fn calculate_p_value_exact(t_value: f64, df: f64) -> f64 {
             f64::NAN
         }
     }
+}
+
+/// Compute slope stderr, p-value, and intercept stderr from pre-computed sums.
+///
+/// Shared by OLS (`ss_effective = Sxx`) and TLS (`ss_effective = Sxx*`).
+/// Applies the same finite-value guards as OLS to keep NaN behaviour consistent
+/// across both estimators.
+pub fn calculate_slope_inference(
+    n: f64,
+    ss_effective: f64,
+    ss_res: f64,
+    slope: f64,
+    x_mean: f64,
+) -> (f64, f64, f64) {
+    let stderr = if n > 2.0 && ss_effective > f64::EPSILON {
+        let sd_res = (ss_res / (n - 2.0)).sqrt();
+        if sd_res.is_finite() && ss_effective > 0.0 {
+            safe_divide(sd_res, ss_effective.sqrt(), "standard error calculation")
+                .unwrap_or(f64::NAN)
+        } else {
+            f64::NAN
+        }
+    } else {
+        f64::NAN
+    };
+
+    let p_value = if n > 2.0 && stderr != 0.0 {
+        calculate_p_value_exact(slope.abs() / stderr, n - 2.0)
+    } else {
+        f64::NAN
+    };
+
+    let intercept_stderr = if n > 2.0 && ss_effective > 0.0 {
+        let sd_res = (ss_res / (n - 2.0)).sqrt();
+        sd_res * ((1.0 / n) + (x_mean * x_mean) / ss_effective).sqrt()
+    } else {
+        f64::NAN
+    };
+
+    (stderr, p_value, intercept_stderr)
 }
 
 #[cfg(test)]

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -105,6 +105,16 @@ class TestTlsRegressor:
         assert regressor.residuals().shape == y.shape
 
 
+def _odrpack_linear_fit(xn, yn):
+    """Fit linear ODR with equal weights; returns the odrpack result."""
+    import odrpack
+
+    def lin(x, b):
+        return b[0] * x + b[1]
+
+    return odrpack.odr_fit(lin, xn, yn, beta0=[1.0, 0.0])
+
+
 class TestTlsRegressorStderr:
     """Tests that TLS standard errors match the Deming regression reference."""
 
@@ -118,11 +128,6 @@ class TestTlsRegressorStderr:
     )
     def test_stderr_matches_odrpack_deming_reference(self, true_slope, noise):
         """Slope stderr must agree with odrpack equal-weight ODR to within 1%."""
-        import odrpack
-
-        def lin(x, b):
-            return b[0] * x + b[1]
-
         rng = np.random.default_rng(seed=1)
         n = 60
         x = np.linspace(0, 10, n)
@@ -130,7 +135,7 @@ class TestTlsRegressorStderr:
         yn = true_slope * x + rng.normal(0, noise, n)
 
         regressor = TlsRegressor(xn, yn)
-        res = odrpack.odr_fit(lin, xn, yn, beta0=[1.0, 0.0])
+        res = _odrpack_linear_fit(xn, yn)
 
         relative_error = abs(regressor.stderr() - res.sd_beta[0]) / res.sd_beta[0]
         assert relative_error < 0.01, (
@@ -140,11 +145,6 @@ class TestTlsRegressorStderr:
 
     def test_intercept_stderr_matches_odrpack_deming_reference(self):
         """Intercept stderr must agree with odrpack equal-weight ODR to within 1%."""
-        import odrpack
-
-        def lin(x, b):
-            return b[0] * x + b[1]
-
         rng = np.random.default_rng(seed=42)
         n = 60
         x = np.linspace(0, 10, n)
@@ -153,7 +153,7 @@ class TestTlsRegressorStderr:
         yn = 10.0 * x + rng.normal(0, noise, n)
 
         regressor = TlsRegressor(xn, yn)
-        res = odrpack.odr_fit(lin, xn, yn, beta0=[1.0, 0.0])
+        res = _odrpack_linear_fit(xn, yn)
 
         relative_error = (
             abs(regressor.intercept_stderr() - res.sd_beta[1]) / res.sd_beta[1]
@@ -182,10 +182,12 @@ class TestTlsRegressorStderr:
         ss_res = np.sum(residuals**2)
         ss_xx = np.sum((xn - np.mean(xn)) ** 2)
         s = np.sqrt(ss_res / (n - 2))
-        ols_formula_stderr = s / np.sqrt(ss_xx)
+        vertical_residual_stderr = s / np.sqrt(ss_xx)
 
-        assert regressor.stderr() > ols_formula_stderr, (
-            "Deming stderr should exceed OLS-formula stderr for steep TLS slopes"
+        ratio = regressor.stderr() / vertical_residual_stderr
+        assert ratio > 1.10, (
+            f"TLS stderr should be at least 10% larger than vertical-residual "
+            f"approximation (got ratio {ratio:.3f})"
         )
 
 

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -163,8 +163,10 @@ class TestTlsRegressorStderr:
             f"odrpack={res.sd_beta[1]:.4f}, relative_error={relative_error * 100:.1f}%"
         )
 
-    def test_stderr_increases_relative_to_ols_approximation_for_steep_slopes(self):
-        """Deming stderr must exceed OLS-formula stderr when slope is steep."""
+    def test_stderr_exceeds_vertical_residual_approximation_when_x_has_measurement_noise(
+        self,
+    ):
+        """TLS stderr must exceed vertical-residual-only approximation when both variables have noise."""
         rng = np.random.default_rng(seed=1)
         n = 60
         true_slope = 20.0

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -105,6 +105,88 @@ class TestTlsRegressor:
         assert regressor.residuals().shape == y.shape
 
 
+class TestTlsRegressorStderr:
+    """Tests that TLS standard errors match the Deming regression reference."""
+
+    @pytest.mark.parametrize(
+        "true_slope,noise",
+        [
+            (5.0, 1.0),
+            (10.0, 2.0),
+            (20.0, 3.0),
+        ],
+    )
+    def test_stderr_matches_odrpack_deming_reference(self, true_slope, noise):
+        """Slope stderr must agree with odrpack equal-weight ODR to within 1%."""
+        import odrpack
+
+        def lin(x, b):
+            return b[0] * x + b[1]
+
+        rng = np.random.default_rng(seed=1)
+        n = 60
+        x = np.linspace(0, 10, n)
+        xn = x + rng.normal(0, noise, n)
+        yn = true_slope * x + rng.normal(0, noise, n)
+
+        regressor = TlsRegressor(xn, yn)
+        res = odrpack.odr_fit(lin, xn, yn, beta0=[1.0, 0.0])
+
+        relative_error = abs(regressor.stderr() - res.sd_beta[0]) / res.sd_beta[0]
+        assert relative_error < 0.01, (
+            f"slope~{true_slope}: rustgression stderr={regressor.stderr():.4f}, "
+            f"odrpack={res.sd_beta[0]:.4f}, relative_error={relative_error * 100:.1f}%"
+        )
+
+    def test_intercept_stderr_matches_odrpack_deming_reference(self):
+        """Intercept stderr must agree with odrpack equal-weight ODR to within 1%."""
+        import odrpack
+
+        def lin(x, b):
+            return b[0] * x + b[1]
+
+        rng = np.random.default_rng(seed=42)
+        n = 60
+        x = np.linspace(0, 10, n)
+        noise = 2.0
+        xn = x + rng.normal(0, noise, n)
+        yn = 10.0 * x + rng.normal(0, noise, n)
+
+        regressor = TlsRegressor(xn, yn)
+        res = odrpack.odr_fit(lin, xn, yn, beta0=[1.0, 0.0])
+
+        relative_error = (
+            abs(regressor.intercept_stderr() - res.sd_beta[1]) / res.sd_beta[1]
+        )
+        assert relative_error < 0.01, (
+            f"intercept_stderr: rustgression={regressor.intercept_stderr():.4f}, "
+            f"odrpack={res.sd_beta[1]:.4f}, relative_error={relative_error * 100:.1f}%"
+        )
+
+    def test_stderr_increases_relative_to_ols_approximation_for_steep_slopes(self):
+        """Deming stderr must exceed OLS-formula stderr when slope is steep."""
+        rng = np.random.default_rng(seed=1)
+        n = 60
+        true_slope = 20.0
+        noise = 3.0
+        x = np.linspace(0, 10, n)
+        xn = x + rng.normal(0, noise, n)
+        yn = true_slope * x + rng.normal(0, noise, n)
+
+        regressor = TlsRegressor(xn, yn)
+
+        beta = regressor.slope()
+        residuals = yn - beta * xn - regressor.intercept()
+        ss_res = np.sum(residuals**2)
+        ss_xx = np.sum((xn - np.mean(xn)) ** 2)
+        s = np.sqrt(ss_res / (n - 2))
+        ols_formula_stderr = s / np.sqrt(ss_xx)
+
+        assert regressor.stderr() > ols_formula_stderr, (
+            "Deming stderr should exceed OLS-formula stderr for steep TLS slopes"
+        )
+
+
 class TestTlsRegressorIntervalsNotImplemented:
     """Tests that TLS interval methods raise NotImplementedError."""
 


### PR DESCRIPTION
<!-- # fix(tls): correct TLS standard error using Deming regression variance estimator -->

## Related URLs

- Issues
  - Closes <https://github.com/connect0459/rustgression/issues/168>
- PRs
  - N/A

## [Required] Overview

`TlsRegressor.stderr()`, `intercept_stderr()`, and `p_value()` returned numerically incorrect values. The underlying Rust function computed standard errors by applying the OLS vertical-residual formula to the TLS slope — treating it as if the TLS slope had been obtained by minimising squared vertical distances. This is statistically incorrect: TLS minimises orthogonal distances, so the fitted slope is systematically larger in absolute value than the OLS slope (attenuation correction), and the OLS variance formula gives no account of this correction. The result was a systematic underestimation of uncertainty that grew with slope magnitude, reaching −22.5% relative error at β ≈ 20 against the scipy.odr / odrpack equal-weight ODR reference.

This PR replaces the formula with the correct Deming (λ=1) variance estimator. For equal measurement error variance in both variables, the ODR covariance matrix uses an effective sum of squares Sxx\* = Σ(xi\* − x̄)², where xi\* is the foot of the perpendicular from each observed point to the TLS line. Because the TLS intercept normal equation implies Σri = 0, the mean x̄\* equals x̄ exactly, and the formula simplifies cleanly:

- `slope_stderr = s / √Sxx*`
- `intercept_stderr = s · √(1/n + x̄² / Sxx*)`
- `p_value` follows from a two-tailed t-test with df = n − 2

The new formula agrees with odrpack equal-weight ODR to within 1% across the range of slopes tested (β ∈ {5, 10, 20} with matched noise variance). Point estimates (`slope`, `intercept`, `r_value`) are not affected.

The Rust code is the only change to production logic; the Python API surface and return types are unchanged. The incorrect equivalence claim in the docstrings is corrected to describe the actual Deming estimator. The standard-error computation is extracted into a shared `calculate_slope_inference` helper in `utils/statistics.rs`, so OLS and TLS now apply the same robustness guards. New tests verify numerical agreement against odrpack; new Rust unit tests cover finite-output, NaN-on-degenerate-input, and the correction-factor ordering for steep slopes with x-noise.

## [Required] Release

- Release date: Anytime
- Release considerations: This is a silent-wrong-output bug fix. Callers who relied on the previously underestimated stderr for threshold checks (e.g. `stderr < 0.5`) may observe values shift upward after upgrading, particularly for steep slopes. No API change.

## Post-Release Verification

- All 119 tests pass in the Docker dev environment (6 commits on this branch).
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [x] Design decisions documented in ADR (if applicable)
- [x] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
