### PR TITLE
feat(core): route numerical diagnostics through Python warnings module

### DIFF
--- a/rustgression/__init__.py
+++ b/rustgression/__init__.py
@@ -43,7 +43,7 @@ __version__ = "0.5.1"
 
 # Check availability of Rust module (actual import is done in _rust_imports.py)
 try:
-    from .rustgression import calculate_ols_regression
+    from .rustgression import NumericalWarning, calculate_ols_regression
 
     # Do nothing on successful import (actual usage is done in other modules)
     del calculate_ols_regression
@@ -66,6 +66,7 @@ try:
     )
 
     __all__ = [
+        "NumericalWarning",
         "OlsMultiRegressionParams",
         "OlsMultiRegressor",
         "OlsRegressionParams",

--- a/rustgression/__init__.py
+++ b/rustgression/__init__.py
@@ -43,7 +43,7 @@ __version__ = "0.5.1"
 
 # Check availability of Rust module (actual import is done in _rust_imports.py)
 try:
-    from .rustgression import NumericalWarning, calculate_ols_regression
+    from .rustgression import calculate_ols_regression
 
     # Do nothing on successful import (actual usage is done in other modules)
     del calculate_ols_regression
@@ -53,7 +53,8 @@ except ImportError as e:
     print(f"Error importing Rust module: {e}", file=sys.stderr)
     print("Rust extension was not properly compiled or installed.", file=sys.stderr)
 
-# Next, import Python wrapper
+# Next, import Python wrapper and public Rust symbols together so that
+# __all__ is only populated when every advertised name is actually bound.
 try:
     from .regression import (
         OlsMultiRegressionParams,
@@ -64,6 +65,7 @@ try:
         TlsRegressor,
         create_regressor,
     )
+    from .rustgression import NumericalWarning
 
     __all__ = [
         "NumericalWarning",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 
 mod regression;
+pub mod warnings;
 
 /// Rust module for performing regression analysis.
 ///
@@ -34,5 +35,9 @@ fn rustgression(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(regression::calculate_tls_regression, m)?)?;
+    m.add(
+        "NumericalWarning",
+        m.py().get_type::<warnings::NumericalWarning>(),
+    )?;
     Ok(())
 }

--- a/src/regression/ols.rs
+++ b/src/regression/ols.rs
@@ -45,8 +45,8 @@ pub fn calculate_ols_regression<'py>(
     // IEEE 754 edge case validation
     let x_slice = x_array.as_slice().unwrap();
     let y_slice = y_array.as_slice().unwrap();
-    validate_finite_array(x_slice, "x")?;
-    validate_finite_array(y_slice, "y")?;
+    validate_finite_array(py, x_slice, "x")?;
+    validate_finite_array(py, y_slice, "y")?;
 
     // Calculate means
     let x_mean = x_array.mean().unwrap();

--- a/src/regression/ols_multi.rs
+++ b/src/regression/ols_multi.rs
@@ -38,11 +38,11 @@ pub fn calculate_ols_multi_regression<'py>(
     let (n, p) = x_view.dim();
 
     let y_slice = y_array.as_slice().unwrap();
-    validate_finite_array(y_slice, "y")?;
+    validate_finite_array(py, y_slice, "y")?;
 
     let x_standard = x_view.as_standard_layout();
     let x_flat = x_standard.as_slice().unwrap();
-    validate_finite_array(x_flat, "x")?;
+    validate_finite_array(py, x_flat, "x")?;
 
     let result = compute_ols_multi_coefficients(x_flat, y_slice, n, p)
         .map_err(pyo3::exceptions::PyValueError::new_err)?;

--- a/src/regression/tls.rs
+++ b/src/regression/tls.rs
@@ -58,8 +58,8 @@ pub fn calculate_tls_regression<'py>(
     // IEEE 754 edge case validation
     let x_slice = x_array.as_slice().unwrap();
     let y_slice = y_array.as_slice().unwrap();
-    validate_finite_array(x_slice, "x")?;
-    validate_finite_array(y_slice, "y")?;
+    validate_finite_array(py, x_slice, "x")?;
+    validate_finite_array(py, y_slice, "y")?;
 
     // Minimum data point check
     if x_array.len() < 2 {
@@ -70,7 +70,7 @@ pub fn calculate_tls_regression<'py>(
 
     let (data_matrix, x_mean, y_mean) = prepare_centered_data(&x_array, &y_array);
 
-    let svd_result = perform_svd_analysis(data_matrix)?;
+    let svd_result = perform_svd_analysis(py, data_matrix)?;
 
     let v_col = find_optimal_singular_vector(&svd_result.v_matrix, &svd_result.singular_values);
 
@@ -113,7 +113,7 @@ fn prepare_centered_data(x_array: &Array1Ref, y_array: &Array1Ref) -> (DMatrix<f
 }
 
 /// SVD analysis and numerical stability check
-fn perform_svd_analysis(data_matrix: DMatrix<f64>) -> PyResult<SvdAnalysisResult> {
+fn perform_svd_analysis(py: Python<'_>, data_matrix: DMatrix<f64>) -> PyResult<SvdAnalysisResult> {
     let svd = SVD::new(data_matrix.clone(), true, true);
 
     let v = if let Some(v) = svd.v_t {
@@ -136,9 +136,12 @@ fn perform_svd_analysis(data_matrix: DMatrix<f64>) -> PyResult<SvdAnalysisResult
     };
 
     if condition_number > 1e12 {
-        eprintln!(
-            "Warning: Matrix condition number is very large ({}), results may be unreliable",
-            condition_number
+        crate::warnings::emit_numerical_warning(
+            py,
+            &format!(
+                "Matrix condition number is very large ({}), results may be unreliable",
+                condition_number
+            ),
         );
     }
 

--- a/src/regression/tls.rs
+++ b/src/regression/tls.rs
@@ -142,7 +142,7 @@ fn perform_svd_analysis(py: Python<'_>, data_matrix: DMatrix<f64>) -> PyResult<S
                 "Matrix condition number is very large ({}), results may be unreliable",
                 condition_number
             ),
-        );
+        )?;
     }
 
     Ok(SvdAnalysisResult {

--- a/src/regression/utils/validation.rs
+++ b/src/regression/utils/validation.rs
@@ -1,11 +1,16 @@
 use pyo3::prelude::*;
 use std::f64;
 
-/// Internal implementation for finite array validation
-fn validate_finite_array_impl<E, F>(array: &[f64], name: &str, error_fn: F) -> Result<(), E>
+/// Internal implementation for finite array validation.
+///
+/// Returns the number of subnormal (non-zero, below f64::MIN_POSITIVE) values
+/// found in the array, so the PyO3 wrapper can emit a single aggregate warning
+/// without repeating the scan.
+fn validate_finite_array_impl<E, F>(array: &[f64], name: &str, error_fn: F) -> Result<usize, E>
 where
     F: Fn(String) -> E,
 {
+    let mut subnormal_count = 0usize;
     for (i, &value) in array.iter().enumerate() {
         if !value.is_finite() {
             if value.is_nan() {
@@ -20,8 +25,11 @@ where
                 )));
             }
         }
+        if value != 0.0 && value.abs() < f64::MIN_POSITIVE {
+            subnormal_count += 1;
+        }
     }
-    Ok(())
+    Ok(subnormal_count)
 }
 
 /// Internal implementation for safe division
@@ -73,19 +81,17 @@ where
 /// PyResult<()>
 ///     Ok(()) on success, error if problems found
 pub fn validate_finite_array(py: Python<'_>, array: &[f64], name: &str) -> PyResult<()> {
-    validate_finite_array_impl(array, name, |msg| {
+    let subnormal_count = validate_finite_array_impl(array, name, |msg| {
         pyo3::exceptions::PyValueError::new_err(msg)
     })?;
-    for (i, &value) in array.iter().enumerate() {
-        if value != 0.0 && value.abs() < f64::MIN_POSITIVE {
-            crate::warnings::emit_numerical_warning(
-                py,
-                &format!(
-                    "Subnormal number detected in {} array at index {}: {}",
-                    name, i, value
-                ),
-            )?;
-        }
+    if subnormal_count > 0 {
+        crate::warnings::emit_numerical_warning(
+            py,
+            &format!(
+                "{} subnormal value(s) detected in {} array; results may lose precision",
+                subnormal_count, name
+            ),
+        )?;
     }
     Ok(())
 }
@@ -118,7 +124,7 @@ mod tests {
     type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
 
     // Test-specific versions of functions that don't depend on PyO3
-    fn validate_finite_array_test(array: &[f64], name: &str) -> TestResult<()> {
+    fn validate_finite_array_test(array: &[f64], name: &str) -> TestResult<usize> {
         validate_finite_array_impl(array, name, |msg| msg.into())
     }
 
@@ -166,11 +172,27 @@ mod tests {
         }
 
         #[test]
-        fn accepts_subnormal_numbers_without_error() {
-            // Test with very small numbers (subnormal)
-            let array = [1.0, 1e-320, 3.0]; // 1e-320 is subnormal
+        fn detects_subnormal_values_and_reports_count_without_error() {
+            let array = [1.0, 1e-320, 3.0]; // 1e-320 is a subnormal f64
             let result = validate_finite_array_test(&array, "test");
-            assert!(result.is_ok()); // Should succeed but print warning
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), 1);
+        }
+
+        #[test]
+        fn counts_multiple_subnormal_elements_independently() {
+            let array = [1e-320, 2e-320, 3.0, 4e-320];
+            let result = validate_finite_array_test(&array, "test");
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), 3);
+        }
+
+        #[test]
+        fn reports_zero_subnormal_count_for_normal_values() {
+            let array = [1.0, 2.0, 3.0];
+            let result = validate_finite_array_test(&array, "test");
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), 0);
         }
 
         #[test]

--- a/src/regression/utils/validation.rs
+++ b/src/regression/utils/validation.rs
@@ -20,13 +20,6 @@ where
                 )));
             }
         }
-        // Subnormal number detection
-        if value != 0.0 && value.abs() < f64::MIN_POSITIVE {
-            eprintln!(
-                "Warning: Subnormal number detected in {} array at index {}: {}",
-                name, i, value
-            );
-        }
     }
     Ok(())
 }
@@ -79,10 +72,22 @@ where
 /// -------
 /// PyResult<()>
 ///     Ok(()) on success, error if problems found
-pub fn validate_finite_array(array: &[f64], name: &str) -> PyResult<()> {
+pub fn validate_finite_array(py: Python<'_>, array: &[f64], name: &str) -> PyResult<()> {
     validate_finite_array_impl(array, name, |msg| {
         pyo3::exceptions::PyValueError::new_err(msg)
-    })
+    })?;
+    for (i, &value) in array.iter().enumerate() {
+        if value != 0.0 && value.abs() < f64::MIN_POSITIVE {
+            crate::warnings::emit_numerical_warning(
+                py,
+                &format!(
+                    "Subnormal number detected in {} array at index {}: {}",
+                    name, i, value
+                ),
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Safe division with zero division and non-finite value checks

--- a/src/regression/utils/validation.rs
+++ b/src/regression/utils/validation.rs
@@ -84,7 +84,7 @@ pub fn validate_finite_array(py: Python<'_>, array: &[f64], name: &str) -> PyRes
                     "Subnormal number detected in {} array at index {}: {}",
                     name, i, value
                 ),
-            );
+            )?;
         }
     }
     Ok(())

--- a/src/warnings.rs
+++ b/src/warnings.rs
@@ -6,11 +6,9 @@ pyo3::create_exception!(
     pyo3::exceptions::PyUserWarning
 );
 
-pub fn emit_numerical_warning(py: Python<'_>, message: &str) {
-    let _ = (|| -> PyResult<()> {
-        let warnings = PyModule::import(py, "warnings")?;
-        let warning_type = py.get_type::<NumericalWarning>();
-        warnings.call_method1("warn", (message, warning_type))?;
-        Ok(())
-    })();
+pub fn emit_numerical_warning(py: Python<'_>, message: &str) -> PyResult<()> {
+    let warnings = PyModule::import(py, "warnings")?;
+    let warning_type = py.get_type::<NumericalWarning>();
+    warnings.call_method1("warn", (message, warning_type))?;
+    Ok(())
 }

--- a/src/warnings.rs
+++ b/src/warnings.rs
@@ -1,0 +1,16 @@
+use pyo3::prelude::*;
+
+pyo3::create_exception!(
+    rustgression,
+    NumericalWarning,
+    pyo3::exceptions::PyUserWarning
+);
+
+pub fn emit_numerical_warning(py: Python<'_>, message: &str) {
+    let _ = (|| -> PyResult<()> {
+        let warnings = PyModule::import(py, "warnings")?;
+        let warning_type = py.get_type::<NumericalWarning>();
+        warnings.call_method1("warn", (message, warning_type))?;
+        Ok(())
+    })();
+}

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -92,6 +92,7 @@ class TestModuleInitialization:
     def test_all_public_symbols_are_importable_from_package(self):
         """Test that all expected components are available."""
         from rustgression import (
+            NumericalWarning,
             OlsMultiRegressionParams,
             OlsMultiRegressor,
             OlsRegressionParams,
@@ -102,6 +103,7 @@ class TestModuleInitialization:
         )
 
         # Check that all components are importable
+        assert NumericalWarning is not None
         assert OlsMultiRegressionParams is not None
         assert OlsMultiRegressor is not None
         assert OlsRegressor is not None
@@ -124,6 +126,7 @@ class TestModuleInitialization:
         import rustgression
 
         expected_items = {
+            "NumericalWarning",
             "OlsMultiRegressionParams",
             "OlsMultiRegressor",
             "OlsRegressionParams",

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -17,11 +17,6 @@ class TestNumericalWarning:
     def test_numerical_warning_is_subclass_of_user_warning(self):
         assert issubclass(NumericalWarning, UserWarning)
 
-    def test_numerical_warning_is_importable_from_package(self):
-        from rustgression import NumericalWarning as W
-
-        assert W is not None
-
 
 class TestConditionNumberWarning:
     """Large SVD condition number must emit NumericalWarning, not write to stderr."""

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,120 @@
+"""
+Tests that numerical diagnostics are routed through Python's warnings
+module and are not written directly to stderr.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from rustgression import NumericalWarning, OlsRegressor, TlsRegressor
+
+
+class TestNumericalWarning:
+    """NumericalWarning must be a subclass of UserWarning."""
+
+    def test_numerical_warning_is_subclass_of_user_warning(self):
+        assert issubclass(NumericalWarning, UserWarning)
+
+    def test_numerical_warning_is_importable_from_package(self):
+        from rustgression import NumericalWarning as W
+
+        assert W is not None
+
+
+class TestConditionNumberWarning:
+    """Large SVD condition number must emit NumericalWarning, not write to stderr."""
+
+    def test_large_condition_number_emits_numerical_warning(self):
+        x = np.array([1e-8, 2e-8, 3e-8])
+        y = np.array([2e-8, 4e-8, 6e-8])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            TlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert len(numerical) >= 1
+
+    def test_condition_number_warning_message_describes_condition_number(self):
+        x = np.array([1e-8, 2e-8, 3e-8])
+        y = np.array([2e-8, 4e-8, 6e-8])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            TlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert any("condition number" in str(w.message).lower() for w in numerical)
+
+    def test_condition_number_warning_can_be_suppressed(self):
+        x = np.array([1e-8, 2e-8, 3e-8])
+        y = np.array([2e-8, 4e-8, 6e-8])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("ignore", NumericalWarning)
+            TlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert len(numerical) == 0
+
+    def test_condition_number_warning_can_be_escalated_to_error(self):
+        x = np.array([1e-8, 2e-8, 3e-8])
+        y = np.array([2e-8, 4e-8, 6e-8])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NumericalWarning)
+            with pytest.raises(NumericalWarning):
+                TlsRegressor(x, y)
+
+    def test_well_conditioned_data_does_not_emit_numerical_warning(self):
+        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        y = np.array([2.1, 3.9, 6.2, 7.8, 10.1])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            TlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert len(numerical) == 0
+
+
+class TestSubnormalWarning:
+    """Subnormal input values must emit NumericalWarning from both OLS and TLS."""
+
+    def test_tls_subnormal_y_values_emit_numerical_warning(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([1e-320, 2e-320, 3e-320])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            TlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert len(numerical) >= 1
+
+    def test_ols_subnormal_y_values_emit_numerical_warning(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([1e-320, 2e-320, 3e-320])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            OlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert len(numerical) >= 1
+
+    def test_subnormal_warning_message_identifies_subnormal_and_array_name(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([1e-320, 2e-320, 3e-320])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            TlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert any("subnormal" in str(w.message).lower() for w in numerical)
+
+    def test_subnormal_warning_can_be_suppressed(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([1e-320, 2e-320, 3e-320])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("ignore", NumericalWarning)
+            TlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert len(numerical) == 0
+
+    def test_normal_values_do_not_emit_subnormal_warning(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([2.0, 4.0, 6.0])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            OlsRegressor(x, y)
+        numerical = [w for w in caught if issubclass(w.category, NumericalWarning)]
+        assert len(numerical) == 0


### PR DESCRIPTION
<!-- # feat(core): route numerical diagnostics through Python warnings module -->

## Related URLs

- Issues
  - Closes <https://github.com/connect0459/rustgression/issues/170>
- PRs
  - N/A

## [Required] Overview

Two numerical diagnostics in the Rust core wrote directly to stderr via `eprintln!`: a large SVD condition number warning emitted by TLS, and a subnormal-number detection emitted by the input validation layer (affecting both OLS and TLS). Because `eprintln!` bypasses Python's I/O layer entirely, callers had no way to suppress these messages, capture them in tests, or escalate them to exceptions — any filtering with `warnings.simplefilter` or `warnings.catch_warnings` had no effect, and the output surfaced as unavoidable noise even for computations whose results were numerically correct (e.g., small-scale TLS input with a large but finite condition number).

This PR routes both diagnostics through Python's `warnings` machinery.

**`NumericalWarning`**: A new `NumericalWarning` exception class (subclass of `UserWarning`) is defined and registered in the Python module. It serves as the category for all machine-precision-level advisories emitted by the library, giving callers a named filter target distinct from generic `UserWarning`.

**Large condition number (TLS)**: When the SVD condition number exceeds 10¹², the diagnostic is now emitted as a `NumericalWarning` via `warnings.warn()` rather than written to stderr. The message text and the threshold are unchanged; only the delivery mechanism changes.

**Subnormal number detection (OLS and TLS)**: When an input array element is nonzero but below `f64::MIN_POSITIVE` (i.e., a IEEE 754 subnormal), the advisory is now emitted as a `NumericalWarning` per element. The message text and the detection logic are unchanged.

Because `warnings.warn()` raises if the active filter for the category is `"error"`, the `emit_numerical_warning` helper propagates the resulting `PyResult::Err` back through the call stack — callers using `warnings.simplefilter("error", NumericalWarning)` will receive an exception instead of a silent continuation. All three warning behaviours — suppress, record, escalate — are verified by the new test suite.

`NumericalWarning` is exported from the package top-level so callers can reference it without reaching into the internal Rust extension module.

## [Required] Release

- Release date: Anytime
- Release considerations: This is a diagnostic delivery change with no change to point estimates, error conditions, or the API surface. The only observable behaviour change is that `eprintln!` output no longer appears on stderr; the same information now travels through the `warnings` module. Callers who previously detected the messages by capturing stderr will need to switch to `warnings.catch_warnings`. `NumericalWarning` is a new public symbol added to `__all__`.

## Post-Release Verification

- All 134 tests pass in both the Docker dev environment and the local Python environment.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [x] Design decisions documented in ADR (if applicable)
- [x] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
