### PR TITLE
chore: replace docker compose exec with local-first dev workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,31 +18,54 @@ This project may be released publicly. All of the following must be written in *
 
 Follow the project commit conventions defined in [`docs/COMMIT_CONVENTIONS.md`](docs/COMMIT_CONVENTIONS.md).
 
+## Development Setup
+
+After cloning, run once:
+
+```bash
+just setup
+```
+
+This installs Python dependencies and installs pre-commit hooks.
+Before running tests or importing the package, build the Rust extension:
+
+```bash
+just build
+```
+
+Run this again whenever Rust source changes.
+
 ## Test Commands
 
 ### Python Tests
 
 ```bash
-docker compose exec -w /workspace rustgression-dev uv run pytest
+uv run pytest
 ```
 
 ### Rust Tests
 
 ```bash
-docker compose exec -w /workspace rustgression-dev cargo test
+cargo test
+```
+
+### Both
+
+```bash
+just test
 ```
 
 ### Rust Coverage
 
 ```bash
 # Install cargo-llvm-cov (first time only)
-docker compose exec -w /workspace rustgression-dev cargo install cargo-llvm-cov
+cargo install cargo-llvm-cov
 
 # Generate coverage report (HTML)
-docker compose exec -w /workspace rustgression-dev cargo llvm-cov --html
+cargo llvm-cov --html
 
 # Generate coverage report (lcov format)
-docker compose exec -w /workspace rustgression-dev cargo llvm-cov --lcov --output-path lcov.info
+cargo llvm-cov --lcov --output-path lcov.info
 ```
 
 ## Project Information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,46 +2,38 @@
 
 ## Prerequisites
 
-- [pre-commit](https://pre-commit.com/) — git hook manager
-- [Docker](https://www.docker.com/) *(optional)* — isolated dev container
-- Rust toolchain + [uv](https://docs.astral.sh/uv/) *(if not using Docker)*
+- [just](https://just.systems/) — command runner
+- [rustup](https://rustup.rs/) — Rust toolchain manager
+- [uv](https://docs.astral.sh/uv/) — Python package manager
 
 ## Setup
 
 ```sh
 git clone https://github.com/connect0459/rustgression
 cd rustgression
+just setup
 ```
 
-**With Docker (recommended):**
-
-```sh
-docker compose up -d
-```
-
-**Without Docker:** install the Rust toolchain and uv locally, then run commands directly (omit the `docker compose exec -w /workspace rustgression-dev` prefix).
-
-### pre-commit hooks
-
-```sh
-pip install pre-commit   # or: brew install pre-commit
-pre-commit install
-```
-
-To run all hooks manually:
-
-```sh
-pre-commit run --all-files
-```
+`just setup` installs Python dependencies and installs pre-commit hooks.
+Run `just build` before first use and after any Rust source changes.
 
 ## Development workflow
 
-See [`docs/development.md`](docs/development.md) for environment setup, test commands, and version management details.
+See [docs/development.md](docs/development.md) for environment setup, test commands, and version management details.
 
-Before opening a pull request, ensure all hooks and tests pass:
+Before opening a pull request, ensure linters and tests pass:
 
 ```sh
-pre-commit run --all-files
+just lint
+just test
+```
+
+Pre-commit hooks installed by `just setup` run additional hygiene checks
+(trailing whitespace, end-of-file, YAML/TOML validation, markdown lint)
+automatically on each `git commit`. To run them across all files manually:
+
+```sh
+uv run pre-commit run --all-files
 ```
 
 ## Testing guidelines
@@ -54,7 +46,7 @@ This project follows **Red → Green → Refactor** (Detroit-school TDD):
 
 ## Commit format
 
-Follow the conventions defined in [`docs/COMMIT_CONVENTIONS.md`](docs/COMMIT_CONVENTIONS.md).
+Follow the conventions defined in [docs/COMMIT_CONVENTIONS.md](docs/COMMIT_CONVENTIONS.md).
 
 ```text
 <type>(<scope>): <subject>
@@ -81,7 +73,7 @@ chore(deps-dev): bump pytest from 7.x to 8.x
 
 1. Fork the repository and create a branch: `feature/xxx`, `fix/xxx`, `docs/xxx`.
 2. Follow the Red → Green → Refactor cycle.
-3. Run `pre-commit run --all-files` and ensure all tests pass.
+3. Run `just lint` and `just test`, and ensure all pass.
 4. Open a pull request — CI runs Rust and Python test suites automatically.
 
 ## Code style

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install just
-RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sh -s -- --to /usr/local/bin \
     && just --version
 
 # Install Rust

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Install just
-RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sh -s -- --to /usr/local/bin \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sh -s -- --to /usr/local/bin --tag 1.54.0 \
     && just --version
 
 # Install Rust

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN apt-get update && apt-get install -y \
   pkg-config \
   && rm -rf /var/lib/apt/lists/*
 
+# Install just
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin \
+    && just --version
+
+# Install Rust
 COPY rust-toolchain.toml .
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@
 - [uv](https://docs.astral.sh/uv/) — Python package manager
 - [just](https://just.systems/) — command runner
 
-On Linux, the following system libraries are required before running `just setup` (scipy depends on them):
+On Linux, the following system packages are required before running `just setup` (scipy depends on them):
 
 ```bash
 sudo apt-get update

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,119 +1,115 @@
 # Development Environment
 
-## Installing apt Packages
+## Prerequisites
 
-The following dependencies are required to run Rust:
+- [rustup](https://rustup.rs/) — Rust toolchain manager (`rust-toolchain.toml` pins the version automatically)
+- [uv](https://docs.astral.sh/uv/) — Python package manager
+- [just](https://just.systems/) — command runner
 
-- cmake
-- BLAS and LAPACK development libraries
-- Fortran compiler
-
-For Debian-based OS, install using the following commands.
+On Linux, the following system libraries are required before running `just setup` (scipy depends on them):
 
 ```bash
 sudo apt-get update
 sudo apt-get install cmake libblas-dev liblapack-dev gfortran
 ```
 
-## Setting Up Python Environment
+On macOS, the Accelerate framework provides these dependencies automatically.
 
-Place `pyproject.toml` in the project root and install with the following command.
+## Setup
+
+After cloning, run once:
 
 ```bash
-uv sync --frozen
+just setup
 ```
 
-## Testing the Created Package
-
-Use `maturin` to perform a clean build from Rust. Install the necessary dependencies and build with the following commands.
+This installs Python dependencies and installs pre-commit hooks.
+Before running tests or importing the package, build the Rust extension:
 
 ```bash
-# Confirm installation of necessary tools
-uv add maturin
-# Clean build
-uv run maturin develop
+just build
 ```
 
-## Docker Development Environment
+Run this again whenever Rust source changes.
 
-You can set up a development environment using Docker Compose. With volume mounting, file changes on the host are reflected in real-time.
-
-### Starting the Development Environment
+## Running Tests and Linters
 
 ```bash
-# Start container in background
+# Python tests only
+uv run pytest
+
+# Rust tests only
+cargo test
+
+# Both
+just test
+
+# Rust and Python linters, check-only (matches CI lint gates)
+just lint
+```
+
+## Running Examples
+
+```bash
+just run-examples
+```
+
+## Docker (Optional)
+
+A Docker environment is available as an alternative to the local setup. It is useful on Linux where
+installing BLAS/LAPACK/gfortran locally is inconvenient. The image builds the Rust toolchain and
+all system dependencies at image-build time.
+
+Start the container and work from inside:
+
+```bash
+# Build and start container
 docker compose up -d
 
-# Or start with logs displayed
-docker compose up
+# Enter the container
+docker compose exec rustgression-dev bash
+
+# Run commands from inside the container (same as local)
+just test
+just lint
 ```
 
-### Running Commands in the Container
+To reset the environment:
 
 ```bash
-# Run tests
-docker compose exec -w /workspace rustgression-dev uv run pytest
+# Rebuild image after Dockerfile changes
+docker compose up --build -d
 
-# Run linting
-docker compose exec -w /workspace rustgression-dev uv run ruff check
-
-# Rebuild the package (after file changes)
-docker compose exec -w /workspace rustgression-dev uv run maturin develop
-```
-
-### Development Environment Management
-
-```bash
-# Stop container
-docker compose stop
-
-# Stop and remove container
-docker compose down
-
-# Rebuild image and recreate container
-docker compose up --build
-
-# Complete removal including volumes
+# Remove container and volumes (full reset)
 docker compose down -v
 ```
 
 ## Version Management
 
-### Version Update Procedure
-
-Use the `scripts/version-update.sh` script to manage project versions consistently.
+Use `scripts/version-update.sh` to update all version files consistently:
 
 ```bash
-# Regular version updates (e.g., 0.2.0 → 0.2.1)
-docker compose exec -w /workspace rustgression-dev ./scripts/version-update.sh 0.2.1
+# Regular version update (e.g., 0.2.0 → 0.2.1)
+./scripts/version-update.sh 0.2.1
 
 # Alpha release
-docker compose exec -w /workspace rustgression-dev ./scripts/version-update.sh 0.3.0-alpha.1
+./scripts/version-update.sh 0.3.0-alpha.1
 
 # Beta release
-docker compose exec -w /workspace rustgression-dev ./scripts/version-update.sh 0.3.0-beta.1
+./scripts/version-update.sh 0.3.0-beta.1
 ```
 
-This script automatically updates the following files.
+This script updates the following files:
 
-- `Cargo.toml` - Rust package version
-- `pyproject.toml` - Python package version
-- `src-py/rustgression/__init__.py` - Package version constant
-- `Cargo.lock` - Dependency lock file
+- `Cargo.toml` — Rust package version
+- `pyproject.toml` — Python package version
+- `src-py/rustgression/__init__.py` — Package version constant
+- `Cargo.lock` — Dependency lock file
 
-### Version Verification
-
-Check version consistency across all files.
+Check version consistency across all files:
 
 ```bash
-docker compose exec -w /workspace rustgression-dev ./scripts/version-check.sh 0.2.1
+./scripts/version-check.sh 0.2.1
 ```
 
-### Important Notes
-
-- Always run tests after version updates
-- Verify version consistency before releases
-- Follow Semantic Versioning (SemVer):
-  - MAJOR: Breaking changes
-  - MINOR: Backward-compatible feature additions
-  - PATCH: Backward-compatible bug fixes
+Always run tests after version updates and verify consistency before releases.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,31 @@
+# First-time setup: install deps and install pre-commit hook
+setup:
+    uv sync --frozen
+    uv run pre-commit install
+
+# Run Rust and Python linters (check-only; matches CI lint gates)
+lint:
+    cargo fmt --all --check
+    cargo clippy --all-targets --all-features -- -D warnings
+    uv run ruff check
+    uv run ruff format --check
+
+# Run Rust and Python formatting
+fmt:
+    cargo fmt
+    uv run ruff format
+    uv run ruff check --fix
+
+# Build the Rust extension
+build:
+    uv run maturin develop
+
+# Run Rust and Python tests (rebuilds extension first to avoid stale bindings)
+test: build
+    cargo test
+    uv run pytest
+
+# Run example scripts
+run-examples: build
+    uv run --extra examples python examples/simple_example.py
+    uv run --extra examples python examples/scientific_example.py


### PR DESCRIPTION
<!-- # chore: replace docker compose exec with local-first dev workflow -->

## Related URLs

- Issues
  - Closes <https://github.com/connect0459/rustgression/issues/185>
- PRs
  - N/A

## [Required] Overview

The project's documented development workflow required `docker compose exec -w /workspace rustgression-dev` as a prefix on every command. This made Docker a hard prerequisite even on macOS, where `rust-toolchain.toml` and `uv` already provide sufficient reproducibility without a container.

This PR makes local development the primary path. Docker is retained as an explicitly optional environment, useful on Linux where BLAS/LAPACK/gfortran are heavy to install locally — the image builds all system dependencies and the Rust toolchain at image-build time.

**justfile**: A `justfile` is introduced as the project's command runner. Six recipes are defined:

- `setup` — one-time first-run: `uv sync --frozen`, `uv run pre-commit install` (build is a separate explicit step)
- `build` — builds the Rust extension via `maturin develop`; shared dependency of `test` and `run-examples`
- `test` — rebuilds the Rust extension first to avoid stale bindings, then runs `cargo test` and `uv run pytest`
- `fmt` — auto-fixes formatting: `cargo fmt`, `ruff format`, `ruff check --fix`
- `lint` — check-only linting that matches CI lint gates exactly: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `ruff check`, `ruff format --check`
- `run-examples` — rebuilds the extension for self-containment, then runs both example scripts with `--extra examples` on demand

Recipes that map to a single well-known command are not wrapped. `lint` and `fmt` are kept as distinct operations: `lint` is safe to run in CI (check-only, no side effects); `fmt` mutates files and is intended for local use before committing.

**Dockerfile**: `just` is added via the official binary install script (`just` is only available in Debian trixie onwards and is absent in the bookworm base image). A `just --version` check is appended to the install step so that a silent install failure surfaces as a build error rather than a runtime surprise. `pre-commit` is removed from apt since it is always invoked via `uv run pre-commit`, making the apt copy dead weight. Contributors working inside the container can use the same `just` recipes as local development.

**Documentation update**: All three documentation files (`CLAUDE.md`, `CONTRIBUTING.md`, `docs/development.md`) are updated to remove `docker compose exec` from every command block. `CONTRIBUTING.md` removes standalone `pre-commit` from prerequisites (it is managed by uv), and adds a note clarifying that pre-commit hygiene hooks (markdown lint, whitespace, YAML/TOML validation) run automatically on each `git commit`. The Docker section in `docs/development.md` is reframed as an optional alternative with an explicit rationale and includes container reset procedures.

No library code, test logic, or CI pipeline is affected.

## [Required] Release

- Release date: Anytime
- Release considerations: Documentation-only change from the library consumer's perspective. Contributors who have existing Docker-based workflows will need to either switch to the local toolchain or work from inside the container (`docker compose exec rustgression-dev bash`).

## Post-Release Verification

- `just setup` completes without error on a fresh clone.
- `just test` rebuilds the extension and runs both test suites successfully.
- `just fmt` applies formatting without error.
- `just lint` passes in check-only mode.
- `docker compose up --build` completes without error (verifies `just` binary install).
- Rollback: Revert the branch.

## Deferred Items

The following topics are intentionally out of scope for this PR and should be revisited in follow-up issues.

### just CI integration

Currently, CI (`ci.yml`) inlines the same lint and test commands that `justfile` defines. This creates a three-way duplication: CI, justfile, and Dockerfile each maintain their own copy. When a flag changes in one place, the others can silently drift.

The natural resolution is to have CI call `just lint` and `just test` directly, making `justfile` the single source of truth. However, this requires evaluating whether installing `just` in the CI environment is appropriate — in particular, whether the added dependency and install step is justified compared to the current approach of inlining well-known commands. This trade-off should be discussed before making the change.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [x] Design decisions documented in ADR (if applicable)
- [x] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
