### PR TITLE
docs: bring api.md up to date with v0.5.x releases

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -108,6 +108,52 @@ print(f"Std Error: {model.stderr():.4f}")
 print(f"Intercept Std Error: {model.intercept_stderr():.4f}")
 ```
 
+## OlsMultiRegressor
+
+Multiple Ordinary Least Squares regression. Fits a model of the form
+y = b₀ + b₁x₁ + … + bₚxₚ by minimizing the sum of squared residuals in y.
+
+### Constructor
+
+```python
+OlsMultiRegressor(x: np.ndarray, y: np.ndarray)
+```
+
+`x` must be a 2D array of shape `(n, p)` where n is the number of observations
+and p is the number of predictor variables. `y` is a 1D response vector of length n.
+
+### Methods
+
+| Method | Return type | Description |
+| :--- | :--- | :--- |
+| `coefficients()` | `np.ndarray` | Shape `(p+1,)` — intercept at index 0, then p slopes |
+| `intercept()` | `float` | Intercept term (b₀) |
+| `r_squared()` | `float` | Coefficient of determination (R²) |
+| `f_statistic()` | `float` | F-statistic for overall model significance |
+| `p_value()` | `float` | P-value associated with the F-statistic |
+| `predict(x)` | `np.ndarray` | Predicted y values; accepts shape `(p,)` or `(m, p)` |
+
+### Example
+
+```python
+import numpy as np
+from rustgression import OlsMultiRegressor
+
+rng = np.random.default_rng(0)
+x = rng.standard_normal((100, 2))
+y = 1.5 * x[:, 0] - 0.8 * x[:, 1] + 2.0 + rng.standard_normal(100) * 0.3
+
+model = OlsMultiRegressor(x, y)
+print(f"Coefficients: {model.coefficients()}")
+print(f"Intercept: {model.intercept():.4f}")
+print(f"R²: {model.r_squared():.4f}")
+print(f"F-statistic: {model.f_statistic():.4f}")
+print(f"P-value: {model.p_value():.4e}")
+
+x_new = np.array([[1.0, -0.5], [0.0, 2.0]])
+print(f"Predictions: {model.predict(x_new)}")
+```
+
 ## OLS vs TLS
 
 | | OLS | TLS |

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,11 +180,18 @@ Raises `ValueError` if an unknown method string is provided.
 import numpy as np
 from rustgression import create_regressor
 
+# "ols" and "tls" accept a 1D x array
 x = np.linspace(0, 10, 100)
 y = 2.0 * x + 1.0 + np.random.normal(0, 0.5, 100)
 
 ols_model = create_regressor(x, y, method="ols")
 tls_model = create_regressor(x, y, method="tls")
+
+# "ols_multi" requires a 2D x array of shape (n, p)
+rng = np.random.default_rng(0)
+x_multi = rng.standard_normal((100, 2))
+y_multi = 1.5 * x_multi[:, 0] - 0.8 * x_multi[:, 1] + 2.0 + rng.standard_normal(100) * 0.3
+multi_model = create_regressor(x_multi, y_multi, method="ols_multi")
 ```
 
 ## OLS vs TLS vs Multi-OLS

--- a/docs/api.md
+++ b/docs/api.md
@@ -154,16 +154,51 @@ x_new = np.array([[1.0, -0.5], [0.0, 2.0]])
 print(f"Predictions: {model.predict(x_new)}")
 ```
 
-## OLS vs TLS
+## create_regressor
 
-| | OLS | TLS |
-| :--- | :--- | :--- |
-| Error direction | Y only | Both X and Y |
-| Use case | Only dependent variable has measurement error | Both variables have measurement error |
-| Algorithm | Rust-backed linear regression | Rust-backed SVD orthogonal regression |
+Factory function that instantiates a regression model by method name.
+
+```python
+create_regressor(
+    x: np.ndarray,
+    y: np.ndarray,
+    method: Literal["ols", "tls", "ols_multi"] = "ols",
+) -> OlsRegressor | TlsRegressor | OlsMultiRegressor
+```
+
+| `method` | Returns |
+| :--- | :--- |
+| `"ols"` | `OlsRegressor` |
+| `"tls"` | `TlsRegressor` |
+| `"ols_multi"` | `OlsMultiRegressor` |
+
+Raises `ValueError` if an unknown method string is provided.
+
+### Example
+
+```python
+import numpy as np
+from rustgression import create_regressor
+
+x = np.linspace(0, 10, 100)
+y = 2.0 * x + 1.0 + np.random.normal(0, 0.5, 100)
+
+ols_model = create_regressor(x, y, method="ols")
+tls_model = create_regressor(x, y, method="tls")
+```
+
+## OLS vs TLS vs Multi-OLS
+
+| | OLS | TLS | Multi-OLS |
+| :--- | :--- | :--- | :--- |
+| Variables | 1 predictor | 1 predictor | p predictors |
+| Error direction | Y only | Both X and Y | Y only |
+| Use case | One predictor, errors only in y | Both variables have measurement error | Multiple predictors, errors only in y |
+| Algorithm | Rust-backed linear regression | Rust-backed SVD orthogonal regression | Rust-backed multiple linear regression |
 
 Use **TLS** when both variables have measurement errors (e.g., sensor data, scientific measurements).
 Use **OLS** when only the dependent variable has errors (e.g., time-series prediction).
+Use **Multi-OLS** when you have multiple independent variables and errors only in y.
 
 ## More Examples
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,8 @@
 
 ## OlsRegressor
 
-Ordinary Least Squares regression implementation.
+Ordinary Least Squares regression. Minimizes the sum of squared residuals in the
+y-direction (Σ(yᵢ − ŷᵢ)²). Assumes errors exist only in the dependent variable y.
 
 ### Constructor
 
@@ -16,10 +17,15 @@ OlsRegressor(x: np.ndarray, y: np.ndarray)
 | :--- | :--- | :--- |
 | `slope()` | `float` | Slope of the regression line |
 | `intercept()` | `float` | Y-intercept of the regression line |
-| `r_value()` | `float` | Correlation coefficient |
+| `r_value()` | `float` | Pearson correlation coefficient |
+| `r_squared()` | `float` | Coefficient of determination (R²) |
 | `p_value()` | `float` | P-value for the slope |
 | `stderr()` | `float` | Standard error of the slope |
 | `intercept_stderr()` | `float` | Standard error of the intercept |
+| `predict(x)` | `np.ndarray` | Predicted y values for input x |
+| `residuals()` | `np.ndarray` | Vertical residuals (y − ŷ) |
+| `confidence_interval(alpha=0.05)` | `dict[str, tuple[float, float]]` | 95% CI for slope and intercept |
+| `prediction_interval(x_new, alpha=0.05)` | `np.ndarray` | Prediction intervals for new x values |
 
 ### Example
 
@@ -34,14 +40,33 @@ model = OlsRegressor(x, y)
 print(f"Slope: {model.slope():.4f}")
 print(f"Intercept: {model.intercept():.4f}")
 print(f"R-value: {model.r_value():.4f}")
+print(f"R²: {model.r_squared():.4f}")
 print(f"P-value: {model.p_value():.4e}")
 print(f"Std Error: {model.stderr():.4f}")
 print(f"Intercept Std Error: {model.intercept_stderr():.4f}")
+
+ci = model.confidence_interval()
+print(f"Slope 95% CI: {ci['slope']}")
+print(f"Intercept 95% CI: {ci['intercept']}")
+
+pi = model.prediction_interval(np.array([5.0, 10.0]))
+print(f"Prediction intervals: {pi}")
 ```
 
 ## TlsRegressor
 
-Total Least Squares (orthogonal) regression implementation.
+Total Least Squares (orthogonal) regression. Minimizes the sum of squared orthogonal
+distances from each point to the regression line (Σdᵢ²). Assumes measurement errors
+exist in both x and y.
+
+> **Note on r_squared():** Returns the squared Pearson correlation coefficient
+> (r²), which does **not** equal 1 − SS\_res / SS\_tot for TLS. TLS minimises
+> orthogonal distances while `residuals()` returns vertical residuals, so the
+> classical coefficient-of-determination identity does not hold.
+>
+> **Raises RuntimeError:** When the null-vector y-component falls below the
+> numerical stability threshold, a `RuntimeError` is raised rather than
+> returning silently incorrect output.
 
 ### Constructor
 
@@ -55,10 +80,15 @@ TlsRegressor(x: np.ndarray, y: np.ndarray)
 | :--- | :--- | :--- |
 | `slope()` | `float` | Slope of the regression line |
 | `intercept()` | `float` | Y-intercept of the regression line |
-| `r_value()` | `float` | Correlation coefficient |
-| `p_value()` | `float` | P-value for the slope |
-| `stderr()` | `float` | Standard error of the slope |
+| `r_value()` | `float` | Pearson correlation coefficient |
+| `r_squared()` | `float` | Squared Pearson correlation (see note above) |
+| `p_value()` | `float` | P-value for the slope (Deming/ODR estimator) |
+| `stderr()` | `float` | Standard error of the slope (Deming/ODR estimator) |
 | `intercept_stderr()` | `float` | Standard error of the intercept |
+| `predict(x)` | `np.ndarray` | Predicted y values for input x |
+| `residuals()` | `np.ndarray` | Vertical residuals (y − ŷ) |
+| `confidence_interval(alpha=0.05)` | — | **Not implemented** — raises `NotImplementedError` |
+| `prediction_interval(x_new, alpha=0.05)` | — | **Not implemented** — raises `NotImplementedError` |
 
 ### Example
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,9 +103,20 @@ model = TlsRegressor(x, y)
 print(f"Slope: {model.slope():.4f}")
 print(f"Intercept: {model.intercept():.4f}")
 print(f"R-value: {model.r_value():.4f}")
+print(f"R² (squared Pearson r): {model.r_squared():.4f}")
 print(f"P-value: {model.p_value():.4e}")
 print(f"Std Error: {model.stderr():.4f}")
 print(f"Intercept Std Error: {model.intercept_stderr():.4f}")
+
+# predict and residuals are supported for TLS
+print(f"Predictions: {model.predict(np.array([5.0, 10.0]))}")
+print(f"Residuals (first 5): {model.residuals()[:5]}")
+
+# confidence_interval and prediction_interval raise NotImplementedError for TLS
+try:
+    model.confidence_interval()
+except NotImplementedError as e:
+    print(f"Not supported: {e}")
 ```
 
 ## OlsMultiRegressor

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,8 +24,8 @@ OlsRegressor(x: np.ndarray, y: np.ndarray)
 | `intercept_stderr()` | `float` | Standard error of the intercept |
 | `predict(x)` | `np.ndarray` | Predicted y values for input x |
 | `residuals()` | `np.ndarray` | Vertical residuals (y − ŷ) |
-| `confidence_interval(alpha=0.05)` | `dict[str, tuple[float, float]]` | 95% CI for slope and intercept |
-| `prediction_interval(x_new, alpha=0.05)` | `np.ndarray` | Prediction intervals for new x values |
+| `confidence_interval(alpha=0.05)` | `dict[str, tuple[float, float]]` | (1−alpha)×100% CI for slope and intercept |
+| `prediction_interval(x_new, alpha=0.05)` | `np.ndarray`, shape `(n, 2)` | Prediction intervals; each row is `[lower, upper]` |
 
 ### Example
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -200,12 +200,8 @@ multi_model = create_regressor(x_multi, y_multi, method="ols_multi")
 | :--- | :--- | :--- | :--- |
 | Variables | 1 predictor | 1 predictor | p predictors |
 | Error direction | Y only | Both X and Y | Y only |
-| Use case | One predictor, errors only in y | Both variables have measurement error | Multiple predictors, errors only in y |
+| Use case | Errors only in y | Both variables have measurement error | Multiple predictors, errors only in y |
 | Algorithm | Rust-backed linear regression | Rust-backed SVD orthogonal regression | Rust-backed multiple linear regression |
-
-Use **TLS** when both variables have measurement errors (e.g., sensor data, scientific measurements).
-Use **OLS** when only the dependent variable has errors (e.g., time-series prediction).
-Use **Multi-OLS** when you have multiple independent variables and errors only in y.
 
 ## More Examples
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,8 +33,9 @@ OlsRegressor(x: np.ndarray, y: np.ndarray)
 import numpy as np
 from rustgression import OlsRegressor
 
+rng = np.random.default_rng(42)
 x = np.linspace(0, 10, 100)
-y = 2.0 * x + 1.0 + np.random.normal(0, 0.5, 100)
+y = 2.0 * x + 1.0 + rng.normal(0, 0.5, 100)
 
 model = OlsRegressor(x, y)
 print(f"Slope: {model.slope():.4f}")
@@ -96,8 +97,9 @@ TlsRegressor(x: np.ndarray, y: np.ndarray)
 import numpy as np
 from rustgression import TlsRegressor
 
+rng = np.random.default_rng(42)
 x = np.linspace(0, 10, 100)
-y = 2.0 * x + 1.0 + np.random.normal(0, 0.5, 100)
+y = 2.0 * x + 1.0 + rng.normal(0, 0.5, 100)
 
 model = TlsRegressor(x, y)
 print(f"Slope: {model.slope():.4f}")
@@ -192,14 +194,15 @@ import numpy as np
 from rustgression import create_regressor
 
 # "ols" and "tls" accept a 1D x array
+rng = np.random.default_rng(42)
 x = np.linspace(0, 10, 100)
-y = 2.0 * x + 1.0 + np.random.normal(0, 0.5, 100)
+y = 2.0 * x + 1.0 + rng.normal(0, 0.5, 100)
 
 ols_model = create_regressor(x, y, method="ols")
 tls_model = create_regressor(x, y, method="tls")
 
 # "ols_multi" requires a 2D x array of shape (n, p)
-rng = np.random.default_rng(0)
+rng = np.random.default_rng(42)
 x_multi = rng.standard_normal((100, 2))
 y_multi = 1.5 * x_multi[:, 0] - 0.8 * x_multi[:, 1] + 2.0 + rng.standard_normal(100) * 0.3
 multi_model = create_regressor(x_multi, y_multi, method="ols_multi")


### PR DESCRIPTION
<!-- # docs: bring api.md up to date with v0.5.x releases -->

## Related URLs

- Issues
  - Refs <https://github.com/connect0459/rustgression/issues/162>
- PRs
  - N/A

## [Required] Overview

`docs/api.md` had not been updated since the v0.5.0 and v0.5.1 releases, leaving several parts of the public API undocumented or inaccurate.

Specifically: both `OlsRegressor` and `TlsRegressor` were missing five methods each (`predict`, `r_squared`, `residuals`, `confidence_interval`, `prediction_interval`). The descriptions of both classes lacked the mathematical precision added in v0.5.1 — neither stated what quantity the method minimises or what error assumption it makes. TLS-specific caveats introduced in v0.5.0 were absent: the `r_squared()` identity does not hold for TLS because TLS minimises orthogonal distances while `residuals()` returns vertical residuals; `confidence_interval()` and `prediction_interval()` raise `NotImplementedError` for TLS; a `RuntimeError` is now raised on numerical instability instead of silently returning incorrect output.

`OlsMultiRegressor` and `create_regressor()` — both present in `__all__` since v0.5.0 — had no documentation at all.

This PR updates `docs/api.md` to reflect the current state of the API:

- OLS and TLS class descriptions now state what is minimised and what error model each assumes.
- All public methods of `OlsRegressor` and `TlsRegressor` are documented, including the TLS-specific behaviour differences.
- A new `OlsMultiRegressor` section covers the multiple-predictor OLS class with its constructor, all accessor methods, and a usage example.
- A new `create_regressor` section documents the factory function and its three accepted method strings.
- The comparison table is extended from two columns (OLS vs TLS) to three (OLS vs TLS vs Multi-OLS).

No library code, tests, CI, or build configuration is affected.

## [Required] Release

- Release date: Anytime
- Release considerations: Documentation-only change. No API or behaviour is modified.

## Deferred Items

- <https://github.com/connect0459/rustgression/issues/188>

## Post-Release Verification

- `docs/api.md` renders correctly on GitHub with all sections intact.
- All method tables, code examples, and blockquote notes display as expected.
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [x] Design decisions documented in ADR (if applicable)
- [x] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
