### PR TITLE
test: capture expected warnings explicitly with pytest.warns

### DIFF
--- a/tests-py/e2e/test_smoke.py
+++ b/tests-py/e2e/test_smoke.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -11,19 +9,20 @@ def test_package_exposes_non_empty_version():
     assert rustgression.__version__
 
 
-@pytest.mark.parametrize(
-    "regressor_cls", [rustgression.OlsRegressor, rustgression.TlsRegressor]
-)
-def test_regressor_returns_finite_results_for_basic_input(regressor_cls):
+def test_ols_regressor_returns_finite_results_for_basic_input():
     x = np.array([1.0, 2.0, 3.0])
     y = np.array([2.0, 4.0, 6.0])
-    ctx = (
-        pytest.warns(NumericalWarning)
-        if regressor_cls is rustgression.TlsRegressor
-        else nullcontext()
-    )
-    with ctx:
-        regressor = regressor_cls(x, y)
+    regressor = rustgression.OlsRegressor(x, y)
+    assert np.isfinite(regressor.slope())
+    assert np.isfinite(regressor.intercept())
+    assert np.isfinite(regressor.r_value())
+
+
+def test_tls_regressor_returns_finite_results_even_when_condition_number_is_infinite():
+    x = np.array([1.0, 2.0, 3.0])
+    y = np.array([2.0, 4.0, 6.0])
+    with pytest.warns(NumericalWarning):
+        regressor = rustgression.TlsRegressor(x, y)
     assert np.isfinite(regressor.slope())
     assert np.isfinite(regressor.intercept())
     assert np.isfinite(regressor.r_value())

--- a/tests-py/e2e/test_smoke.py
+++ b/tests-py/e2e/test_smoke.py
@@ -1,7 +1,10 @@
+from contextlib import nullcontext
+
 import numpy as np
 import pytest
 
 import rustgression
+from rustgression import NumericalWarning
 
 
 def test_package_exposes_non_empty_version():
@@ -14,7 +17,13 @@ def test_package_exposes_non_empty_version():
 def test_regressor_returns_finite_results_for_basic_input(regressor_cls):
     x = np.array([1.0, 2.0, 3.0])
     y = np.array([2.0, 4.0, 6.0])
-    regressor = regressor_cls(x, y)
+    ctx = (
+        pytest.warns(NumericalWarning)
+        if regressor_cls is rustgression.TlsRegressor
+        else nullcontext()
+    )
+    with ctx:
+        regressor = regressor_cls(x, y)
     assert np.isfinite(regressor.slope())
     assert np.isfinite(regressor.intercept())
     assert np.isfinite(regressor.r_value())

--- a/tests-py/integration/conftest.py
+++ b/tests-py/integration/conftest.py
@@ -1,0 +1,10 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def sample_data():
+    np.random.seed(42)
+    x = np.linspace(0, 10, 100)
+    y = 2 * x + 1 + np.random.normal(0, 0.5, 100)
+    return x, y

--- a/tests-py/integration/test_base.py
+++ b/tests-py/integration/test_base.py
@@ -13,20 +13,6 @@ from rustgression import (
 )
 
 
-@pytest.fixture
-def sample_data():
-    """Generate sample data for testing.
-
-    Returns:
-        tuple: A tuple containing the input features (x) and the target values (y).
-    """
-    np.random.seed(42)
-    x = np.linspace(0, 10, 100)
-    # y = 2x + 1 + noise
-    y = 2 * x + 1 + np.random.normal(0, 0.5, 100)
-    return x, y
-
-
 class TestCreateRegressor:
     """Tests for the factory function for creating regressors."""
 

--- a/tests-py/integration/test_comparison.py
+++ b/tests-py/integration/test_comparison.py
@@ -8,20 +8,6 @@ import pytest
 from rustgression import NumericalWarning, OlsRegressor, TlsRegressor
 
 
-@pytest.fixture
-def sample_data():
-    """Generate sample data for testing.
-
-    Returns:
-        tuple: A tuple containing the input features (x) and the target values (y).
-    """
-    np.random.seed(42)
-    x = np.linspace(0, 10, 100)
-    # y = 2x + 1 + noise
-    y = 2 * x + 1 + np.random.normal(0, 0.5, 100)
-    return x, y
-
-
 class TestMethodComparison:
     """Tests for comparing OLS and TLS regression methods."""
 

--- a/tests-py/integration/test_comparison.py
+++ b/tests-py/integration/test_comparison.py
@@ -5,7 +5,7 @@ Tests for comparing OLS and TLS regression methods.
 import numpy as np
 import pytest
 
-from rustgression import OlsRegressor, TlsRegressor
+from rustgression import NumericalWarning, OlsRegressor, TlsRegressor
 
 
 @pytest.fixture
@@ -50,7 +50,8 @@ class TestMethodComparison:
         y = np.array(y_data)
 
         ols = OlsRegressor(x, y)
-        tls = TlsRegressor(x, y)
+        with pytest.warns(NumericalWarning):
+            tls = TlsRegressor(x, y)
 
         # For perfect correlation, correlation coefficient should be 1.0 or -1.0
         # but slope and intercept may differ due to TLS algorithm characteristics

--- a/tests-py/integration/test_edge_cases.py
+++ b/tests-py/integration/test_edge_cases.py
@@ -163,9 +163,7 @@ class TestRegressorEdgeCases:
         """
         x = np.array([1e-150, 2e-150, 3e-150])
         y = np.array([2e-150, 4e-150, 6e-150])
-        with pytest.warns(RuntimeWarning):
-            ref = stats.linregress(x, y)
 
         regressor = OlsRegressor(x, y)
 
-        assert abs(regressor.r_value() - ref.rvalue) < 1e-10
+        assert abs(regressor.r_value() - 1.0) < 1e-10

--- a/tests-py/integration/test_edge_cases.py
+++ b/tests-py/integration/test_edge_cases.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from scipy import stats
 
-from rustgression import OlsRegressor, TlsRegressor
+from rustgression import NumericalWarning, OlsRegressor, TlsRegressor
 
 
 class TestRegressorEdgeCases:
@@ -18,7 +18,8 @@ class TestRegressorEdgeCases:
         y = np.array([2.0, 4.0, 6.0])
 
         ols = OlsRegressor(x, y)
-        tls = TlsRegressor(x, y)
+        with pytest.warns(NumericalWarning):
+            tls = TlsRegressor(x, y)
 
         # Test __repr__ method (line 135 in base.py)
         ols_repr = repr(ols)
@@ -66,11 +67,13 @@ class TestRegressorEdgeCases:
         y = np.array([2.0, 4.0, 6.0])
 
         ols = OlsRegressor(x, y)
-        tls = TlsRegressor(x, y)
+        with pytest.warns(NumericalWarning):
+            tls = TlsRegressor(x, y)
 
-        # Test get_params method exists and returns something
-        ols_params = ols.get_params()
-        tls_params = tls.get_params()
+        with pytest.warns(DeprecationWarning):
+            ols_params = ols.get_params()
+        with pytest.warns(DeprecationWarning):
+            tls_params = tls.get_params()
 
         # Basic validation that params are returned
         assert ols_params is not None
@@ -91,7 +94,8 @@ class TestRegressorEdgeCases:
         y = np.array([1.5, 3.5, 5.5, 7.5])
 
         regressor = OlsRegressor(x, y)
-        params = regressor.get_params()
+        with pytest.warns(DeprecationWarning):
+            params = regressor.get_params()
 
         # Test that properties match params
         assert abs(regressor.slope() - params.slope) < 1e-10
@@ -159,7 +163,8 @@ class TestRegressorEdgeCases:
         """
         x = np.array([1e-150, 2e-150, 3e-150])
         y = np.array([2e-150, 4e-150, 6e-150])
-        ref = stats.linregress(x, y)
+        with pytest.warns(RuntimeWarning):
+            ref = stats.linregress(x, y)
 
         regressor = OlsRegressor(x, y)
 

--- a/tests-py/integration/test_ols.py
+++ b/tests-py/integration/test_ols.py
@@ -11,20 +11,6 @@ from statsmodels.tools import add_constant
 from rustgression import OlsRegressionParams, OlsRegressor
 
 
-@pytest.fixture
-def sample_data():
-    """Generate sample data for testing.
-
-    Returns:
-        tuple: A tuple containing the input features (x) and the target values (y).
-    """
-    np.random.seed(42)
-    x = np.linspace(0, 10, 100)
-    # y = 2x + 1 + noise
-    y = 2 * x + 1 + np.random.normal(0, 0.5, 100)
-    return x, y
-
-
 class TestOlsRegressor:
     """Tests for the OlsRegressor class."""
 

--- a/tests-py/integration/test_tls.py
+++ b/tests-py/integration/test_tls.py
@@ -8,20 +8,6 @@ import pytest
 from rustgression import NumericalWarning, TlsRegressionParams, TlsRegressor
 
 
-@pytest.fixture
-def sample_data():
-    """Generate sample data for testing.
-
-    Returns:
-        tuple: A tuple containing the input features (x) and the target values (y).
-    """
-    np.random.seed(42)
-    x = np.linspace(0, 10, 100)
-    # y = 2x + 1 + noise
-    y = 2 * x + 1 + np.random.normal(0, 0.5, 100)
-    return x, y
-
-
 class TestTlsRegressor:
     """Tests for the TlsRegressor class."""
 

--- a/tests-py/integration/test_tls.py
+++ b/tests-py/integration/test_tls.py
@@ -5,7 +5,7 @@ Tests for Total Least Squares (TLS) regression.
 import numpy as np
 import pytest
 
-from rustgression import TlsRegressionParams, TlsRegressor
+from rustgression import NumericalWarning, TlsRegressionParams, TlsRegressor
 
 
 @pytest.fixture
@@ -70,7 +70,8 @@ class TestTlsRegressor:
         x = np.array(x_data)
         y = np.array(y_data)
 
-        regressor = TlsRegressor(x, y)
+        with pytest.warns(NumericalWarning):
+            regressor = TlsRegressor(x, y)
 
         assert abs(regressor.slope() - expected_slope) < 1e-10, (
             f"Slope mismatch: expected {expected_slope}, got {regressor.slope()}"
@@ -84,7 +85,8 @@ class TestTlsRegressor:
         # Minimum data points: y = 3x, so TLS slope=3, intercept=0
         x = np.array([1.0, 2.0])
         y = np.array([3.0, 6.0])
-        regressor = TlsRegressor(x, y)
+        with pytest.warns(NumericalWarning):
+            regressor = TlsRegressor(x, y)
         assert abs(regressor.slope() - 3.0) < 1e-10
         assert abs(regressor.intercept() - 0.0) < 1e-10
 


### PR DESCRIPTION
<!-- # test: capture expected warnings explicitly with pytest.warns -->

## Related URLs

- Issues
  - Refs <https://github.com/connect0459/rustgression/pull/182>
- PRs
  - N/A

## [Required] Overview

Running `uv run pytest` emitted 14 warnings that had no explicit owner in the test suite. Three categories were involved:

**NumericalWarning (10 occurrences)** — `TlsRegressor` emits `NumericalWarning` when the SVD matrix condition number is infinite, which happens whenever the input data is perfectly linear. Tests that intentionally verified `TlsRegressor` behaviour on perfect data were not capturing this warning, so it leaked into pytest's warning summary.

**DeprecationWarning (3 occurrences)** — Tests that verify the deprecated `get_params()` API were calling the method without wrapping it in `pytest.warns(DeprecationWarning)`, so the warning surfaced as noise rather than as a verified assertion.

**RuntimeWarning (1 occurrence)** — `scipy.stats.linregress` raises a `RuntimeWarning` (divide by zero) when called with values at extreme small scale (1e-150). The test that uses scipy as a reference for this underflow edge case was not capturing it.

Each affected call site is now wrapped in `pytest.warns()` with the appropriate warning class. This turns a previously silent assumption ("this code path warns") into an explicit specification that will fail the test if the warning stops being emitted or changes category.

A code review of this initial fix surfaced three additional improvements, each committed separately:

- **Smoke test split**: The parametrized smoke test used `nullcontext` to paper over the asymmetry between `OlsRegressor` (no warning) and `TlsRegressor` (warning on perfect data). Replaced by two named tests that each state their own preconditions and expected warning behaviour.
- **scipy RuntimeWarning dependency removed**: The underflow test compared against `scipy.stats.linregress`, which emits a `RuntimeWarning` on 1e-150 scale input. If scipy fixes this computation in a future release, `pytest.warns(RuntimeWarning)` would fail with `DID NOT WARN` even though our result is correct. Since the input data is perfectly linear, the expected `r_value` is exactly 1.0; the test is now self-contained.
- **`sample_data` fixture consolidated**: The fixture was defined identically in four integration test modules. Moved to `tests-py/integration/conftest.py`, the canonical pytest location for shared fixtures.

## [Required] Release

- Release date: Anytime
- Release considerations: Test-only change. No library code, API surface, or behaviour is affected.

## Post-Release Verification

- All 136 tests pass with no warnings: `uv run pytest`
- Rollback: Revert the branch.

## [Required] Quality Checklist

### Please check all items before merging

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/test-and-build.yml)
- [x] Coverage is maintained (target 80%+)
- [x] Design decisions documented in ADR (if applicable)
- [x] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently

> 💡 **Important**: This checklist ensures quality. Please verify all items before requesting review.
