### PR TITLE
chore: add just recipes for version scripts and update docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,6 @@ without this information.
 - [ ] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
 - [ ] **Code Comments**: Code comments and doc-comments are in sync with the changes
 - [ ] **Reference Docs**: `docs/api.md` is updated for any public API change
-- [ ] **Version Update** (for release PRs): Executed `./scripts/version-update.sh <new-version>` to update all version files consistently
+- [ ] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently
 
 > **Important**: This checklist ensures quality. Please verify all items before requesting review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,14 +84,14 @@ This is a Rust-Python hybrid project that implements fast Total Least Squares (T
 Use the version update script to update all version files consistently:
 
 ```bash
-./scripts/version-update.sh 0.2.1
-./scripts/version-update.sh 0.3.0-alpha.1
+just version-update 0.2.1
+just version-update 0.3.0-alpha.1
 ```
 
 Check version consistency across all files:
 
 ```bash
-./scripts/version-check.sh 0.2.1
+just version-check 0.2.1
 ```
 
 The update script handles different version formats:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,30 +94,31 @@ docker compose down -v
 
 ## Version management
 
-Use `scripts/version-update.sh` to update all version files consistently:
+Use `just version-update` to update all version files consistently:
 
 ```bash
 # Regular version update (e.g., 0.2.0 → 0.2.1)
-./scripts/version-update.sh 0.2.1
+just version-update 0.2.1
 
 # Alpha release
-./scripts/version-update.sh 0.3.0-alpha.1
+just version-update 0.3.0-alpha.1
 
 # Beta release
-./scripts/version-update.sh 0.3.0-beta.1
+just version-update 0.3.0-beta.1
 ```
 
-This script updates the following files:
+This command updates the following files:
 
 - `Cargo.toml` — Rust package version
 - `pyproject.toml` — Python package version
 - `src-py/rustgression/__init__.py` — Package version constant
-- `Cargo.lock` — Dependency lock file
+- `Cargo.lock` — Rust dependency lock file
+- `uv.lock` — Python dependency lock file
 
 Check version consistency across all files:
 
 ```bash
-./scripts/version-check.sh 0.2.1
+just version-check 0.2.1
 ```
 
 Always run tests after version updates and verify consistency before releases.

--- a/justfile
+++ b/justfile
@@ -29,3 +29,11 @@ test: build
 run-examples: build
     uv run --extra examples python examples/simple_example.py
     uv run --extra examples python examples/scientific_example.py
+
+# Check version consistency across all files
+version-check VERSION:
+    ./scripts/version-check.sh {{VERSION}}
+
+# Update version across all files (Cargo.toml, pyproject.toml, __init__.py, lock files)
+version-update VERSION:
+    ./scripts/version-update.sh {{VERSION}}


### PR DESCRIPTION
<!-- # chore: add just recipes for version scripts and update docs -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

The project already uses `just` as the standard task runner for every development operation — setup, build, test, lint, and formatting. Version management was the one exception: contributors had to invoke `./scripts/version-update.sh` and `./scripts/version-check.sh` directly, breaking the assumption that `just --list` shows everything needed to work on the project.

This PR adds `version-update` and `version-check` recipes to the `justfile`. The recipes delegate to the existing shell scripts unchanged, so the underlying logic — semver validation, downgrade detection, multi-file consistency checks — is unaffected.

Documentation that referenced the direct script paths (`CLAUDE.md`, `CONTRIBUTING.md`, and the PR template) is updated to reference the `just` commands instead. CI workflows (`release.yml`, `ci.yml`) are left untouched: they call the scripts directly, which is correct — adding `just` as a CI dependency to wrap a script call would be unnecessary overhead.

## Scope of Change

- [x] Tooling / CI
- [x] Documentation

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- N/A — no code paths are exercised. The `just` recipes delegate directly to the existing scripts with no added logic.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: Code comments and doc-comments are in sync with the changes
- [x] **Reference Docs**: `docs/api.md` is updated for any public API change
- [x] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
