### PR TITLE
ci: extend paths filter with .python-version and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
         with:
           filters: |
             code:
-              - '.github/workflows/ci.yml'
-              - '.python-version'
               - 'examples/**'
               - 'scripts/**'
               - 'src/**'
               - 'src-py/**'
               - 'tests-py/**'
+              - '.github/workflows/ci.yml'
+              - '.python-version'
               - 'Cargo.lock'
               - 'Cargo.toml'
               - 'pyproject.toml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           filters: |
             code:
               - '.github/workflows/ci.yml'
+              - '.python-version'
+              - 'examples/**'
               - 'scripts/**'
               - 'src/**'
               - 'src-py/**'
@@ -111,8 +113,8 @@ jobs:
           uv run python --version
           rustc --version
 
-          # Sync dependencies from pyproject.toml (including main and dev dependencies)
-          uv sync --frozen
+          # Sync dependencies from pyproject.toml (including main, dev, and examples dependencies)
+          uv sync --frozen --extra examples
 
       # Rust lint and format checks
       - name: Lint and format Rust
@@ -184,6 +186,18 @@ jobs:
 
           # Run tests
           uv run pytest
+
+      # Run examples as smoke tests for the public API
+      - name: Run examples
+        if: steps.filter.outputs.code == 'true'
+        shell: bash
+        run: |
+          echo "Running examples..."
+          for f in examples/*.py; do
+            echo "Running $f..."
+            uv run python "$f"
+          done
+          echo "All examples passed!"
 
       # Success message when no relevant changes are detected
       - name: Skip CI checks (no relevant changes)


### PR DESCRIPTION
<!-- # ci: extend paths filter with .python-version and examples -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

Two entries were missing from the `paths-filter` step in `ci.yml`, each for a distinct reason.

**`.python-version`** — `uv` reads this file to select the Python interpreter for every `uv run` and `uv sync` invocation. Without it in the filter, a Python version bump (e.g. `3.11` → `3.12`) would not trigger a CI run, meaning compatibility with the new runtime would go unverified until someone ran CI manually.

**`examples/**`** — the example scripts are the canonical public API usage samples referenced in the README. If an API change breaks them, neither `cargo test` nor `uv run pytest` would catch it, because the examples are outside the test suite. A new "Run examples" step is added after the pytest run to execute all `examples/*.py` files as end-to-end smoke tests against the installed wheel.

The filter entries are also reordered: directories first (alphabetical), then files (alphabetical), to make the list easier to scan as it grows.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- N/A — CI configuration only. The new "Run examples" step is itself the test addition; no library code paths are affected.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: Code comments and doc-comments are in sync with the changes
- [x] **Reference Docs**: `docs/api.md` is updated for any public API change
- [x] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
