### PR TITLE
docs: add release workflow guide and version comparison links to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+<!--
+When cutting a new release, update THREE places in this file:
+
+1. Rename [Unreleased] to [X.Y.Z] with today's date (above).
+2. Update the reference links at the very bottom of this file:
+    - Change [Unreleased] to compare the new tag against HEAD.
+    - Add [X.Y.Z] comparing the new tag against the previous tag.
+3. After the PR is merged, create a GitHub Release (this creates the remote
+   tag). Pull main first so HEAD is the merge commit, then use `--target main`
+   or pass the full 40-character SHA — the GitHub API rejects abbreviated SHAs:
+
+    ```console
+    git checkout main && git pull origin main
+    gh release create vX.Y.Z --title "vX.Y.Z" \
+      --notes-file path/to/gh-release-draft.md \
+      --target main
+    ```
+
+see: <https://github.com/connect0459/rustgression/pull/200>
+-->
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -83,3 +104,16 @@ Initial public release.
 ## [0.2.0] - 2025-07-31
 
 Initial public release.
+
+---
+
+[Unreleased]: <https://github.com/connect0459/rustgression/compare/v0.5.1...HEAD>
+[0.5.1]: <https://github.com/connect0459/rustgression/compare/v0.5.0...v0.5.1>
+[0.5.0]: <https://github.com/connect0459/rustgression/compare/v0.4.1...v0.5.0>
+[0.4.1]: <https://github.com/connect0459/rustgression/compare/v0.4.0...v0.4.1>
+[0.4.0]: <https://github.com/connect0459/rustgression/compare/v0.3.1...v0.4.0>
+[0.3.1]: <https://github.com/connect0459/rustgression/compare/v0.3.0...v0.3.1>
+[0.3.0]: <https://github.com/connect0459/rustgression/compare/v0.2.2...v0.3.0>
+[0.2.2]: <https://github.com/connect0459/rustgression/compare/v0.2.1...v0.2.2>
+[0.2.1]: <https://github.com/connect0459/rustgression/compare/v0.2.0...v0.2.1>
+[0.2.0]: <https://github.com/connect0459/rustgression/releases/tag/v0.2.0>


### PR DESCRIPTION
<!-- # docs: add release workflow guide and version comparison links to CHANGELOG -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

Two independent improvements to `CHANGELOG.md` that make release maintenance easier and
the version history more navigable.

**Release workflow guide** — a comment block added at the top of the file documents the
three-step process maintainers must follow when cutting a release: rename `[Unreleased]`
to the new version with today's date, update the reference links at the bottom, and
create the GitHub Release after the merge commit lands on main. The exact `gh release
create` command (including the `--target main` flag and the note that the GitHub API
rejects abbreviated SHAs) is included so maintainers do not need to rediscover these
details each release cycle.

**Version comparison links** — reference-style links for all published versions
(`[Unreleased]` through `[0.2.0]`) are appended at the bottom of the file. These links
enable the [Keep a Changelog](https://keepachangelog.com) convention of having each
version header link to the corresponding GitHub compare view, making it easy to jump
from a version entry to its full diff.

## Scope of Change

- [x] Documentation

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- N/A — documentation-only change. No library code paths are affected.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: Code comments and doc-comments are in sync with the changes
- [x] **Reference Docs**: `docs/api.md` is updated for any public API change
- [x] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
