### PR TITLE
chore: bump version to 0.6.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-29
+
+### Added
+
+- **OlsMultiRegressor**: new class for multi-predictor OLS regression backed by a Rust
+  implementation (`calculate_ols_multi_regression`); supports `predict()`, `r_squared()`,
+  `f_statistic()`, `p_value()`, and `get_params()`; also accessible via `create_regressor("ols_multi")`
+- **BaseRegressor**: `r_squared()` — returns the coefficient of determination (R²)
+- **BaseRegressor**: `residuals()` — returns vertical residuals `y − ŷ`
+- **OlsRegressor**: `confidence_interval(alpha)` — t-based confidence intervals for slope and intercept
+- **OlsRegressor**: `prediction_interval(x_new, alpha)` — t-based prediction intervals for new observations
+  (`TlsRegressor` raises `NotImplementedError` for both; TLS bootstrap intervals are deferred)
+- **NumericalWarning**: new warning type emitted when subnormal input values are detected;
+  exported from the package public API and routed through Python's `warnings` module
+
+### Fixed
+
+- **TLS**: replace OLS stderr formula with the Deming orthogonal-regression formula for more
+  accurate slope and intercept standard errors
+- **OLS**: fix product underflow in `r_value()` for sub-epsilon x variance using a scale-aware
+  `compute_r_value` approach
+- **OLS**: add overflow guard for intercept on extreme-scale inputs for consistency with slope
+- **TlsRegressor**: `.pyi` stub now correctly declares `NoReturn` on `confidence_interval` and
+  `prediction_interval`
+- **deps**: add `scipy` to runtime dependencies (required by `confidence_interval` and
+  `prediction_interval` but was previously missing)
+- **`__init__.pyi`**: add missing exports (`NumericalWarning`, `OlsMultiRegressor`,
+  `OlsMultiRegressionParams`) and `"ols_multi"` literal to `create_regressor` overload;
+  resolves type errors for mypy/pyright users (#198)
+
+### Changed
+
+- **src layout**: Python package moved from `rustgression/` to `src-py/rustgression/`
+- **test layout**: tests reorganized under `tests-py/integration/` and `tests-py/e2e/` tiers
+- **NumericalWarning**: numerical diagnostics previously emitted via `eprintln!` are now
+  routed through Python's `warnings` module so callers can suppress or escalate them
+
+### Miscellaneous
+
+- **ci**: improve paths-filter entries and clean up redundant workflow steps
+- **dev**: simplify Docker dev environment to a local-first workflow
+- **chore**: add `just version-update` and `just version-check` recipes; include `CHANGELOG.md` in source distribution
+- **docs**: consolidate development and commit guidelines into `CONTRIBUTING.md`
+- **chore**: remove redundant `scipy` from `optional-dependencies.examples` after its
+  promotion to core runtime dependency (#198)
+
 ## [0.5.1] - 2026-05-28
 
 ### Miscellaneous
@@ -107,7 +153,8 @@ Initial public release.
 
 ---
 
-[Unreleased]: <https://github.com/connect0459/rustgression/compare/v0.5.1...HEAD>
+[Unreleased]: <https://github.com/connect0459/rustgression/compare/v0.6.0...HEAD>
+[0.6.0]: <https://github.com/connect0459/rustgression/compare/v0.5.1...v0.6.0>
 [0.5.1]: <https://github.com/connect0459/rustgression/compare/v0.5.0...v0.5.1>
 [0.5.0]: <https://github.com/connect0459/rustgression/compare/v0.4.1...v0.5.0>
 [0.4.1]: <https://github.com/connect0459/rustgression/compare/v0.4.0...v0.4.1>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **OlsMultiRegressor**: new class for multi-predictor OLS regression backed by a Rust
   implementation (`calculate_ols_multi_regression`); supports `predict()`, `r_squared()`,
-  `f_statistic()`, `p_value()`, and `get_params()`; also accessible via `create_regressor("ols_multi")`
+  `f_statistic()`, `p_value()`, and `get_params()`; also accessible via `create_regressor(x, y, method="ols_multi")`
 - **BaseRegressor**: `r_squared()` — returns the coefficient of determination (R²)
 - **BaseRegressor**: `residuals()` — returns vertical residuals `y − ŷ`
 - **OlsRegressor**: `confidence_interval(alpha)` — t-based confidence intervals for slope and intercept

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustgression"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "nalgebra 0.35.0",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustgression"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors = ["connect0459 <connect0459@gmail.com>"]
 description = "Fast OLS and TLS regression using Rust backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rustgression"
-version = "0.5.1"
+version = "0.6.0"
 description = "Fast OLS and TLS regression using Rust backend"
 authors = [{ name = "connect0459", email = "connect0459@gmail.com" }]
 readme = "README.md"

--- a/src-py/rustgression/__init__.py
+++ b/src-py/rustgression/__init__.py
@@ -2,29 +2,40 @@
 rustgression
 ===========
 
-A Python package that implements fast Total Least Squares (TLS) regression.
+A Python package for fast OLS and TLS regression using a Rust backend.
 
-This package provides high-performance TLS (orthogonal) regression analysis using a backend implemented in Rust. It supports both ordinary least squares (OLS) regression and TLS regression.
+This package provides high-performance regression analysis with a backend
+implemented in Rust. It supports ordinary least squares (OLS) regression
+for single and multiple predictors, and Total Least Squares (TLS) orthogonal
+regression.
 
 Main Features
 -------------
 - Fast Rust backend
-- Total Least Squares (TLS) regression
-- Ordinary Least Squares (OLS) regression
+- Ordinary Least Squares (OLS) single-predictor regression
+- Ordinary Least Squares (OLS) multi-predictor regression
+- Total Least Squares (TLS) orthogonal regression
 - User-friendly Python interface
 
 Classes
 -------
 - OlsRegressor
-    Class for performing regression analysis using ordinary least squares.
+    Single-predictor OLS regression.
+
+- OlsMultiRegressor
+    Multi-predictor OLS regression.
+
+- OlsMultiRegressionParams
+    Result dataclass returned by OlsMultiRegressor.get_params().
 
 - TlsRegressor
-    Class for performing regression analysis using Total Least Squares.
+    Total Least Squares (orthogonal) regression.
 
 Functions
 ---------
 - create_regressor
-    Factory function for creating a regression analyzer.
+    Factory function for creating a regressor (supports "ols", "tls",
+    "ols_multi").
 
 References
 ----------
@@ -33,9 +44,13 @@ Computational Aspects and Analysis. SIAM.
 
 Examples
 --------
+>>> import numpy as np
 >>> import rustgression
->>> regressor = rustgression.create_regressor()
->>> result = regressor.fit(X, y)
+>>> x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+>>> y = np.array([2.1, 4.0, 5.9, 8.1, 10.0])
+>>> regressor = rustgression.create_regressor(x, y)
+>>> regressor.slope()
+2.0...
 """
 
 # Package version

--- a/src-py/rustgression/__init__.py
+++ b/src-py/rustgression/__init__.py
@@ -39,7 +39,7 @@ Examples
 """
 
 # Package version
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 # Check availability of Rust module (actual import is done in _rust_imports.py)
 try:

--- a/src-py/rustgression/__init__.pyi
+++ b/src-py/rustgression/__init__.pyi
@@ -16,7 +16,7 @@ from .regression.tls import TlsRegressor
 
 __version__: str
 
-class NumericalWarning(Warning): ...
+class NumericalWarning(UserWarning): ...
 
 def create_regressor(
     x: NDArray[np.floating],

--- a/uv.lock
+++ b/uv.lock
@@ -1303,7 +1303,7 @@ wheels = [
 
 [[package]]
 name = "rustgression"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
<!-- # chore: bump version to 0.6.0 and update CHANGELOG -->

## Related Links

- Issues
  - N/A
- PRs
  - <https://github.com/connect0459/rustgression/pull/154>
  - <https://github.com/connect0459/rustgression/pull/155>
  - <https://github.com/connect0459/rustgression/pull/156>
  - <https://github.com/connect0459/rustgression/pull/157>
  - <https://github.com/connect0459/rustgression/pull/158>
  - <https://github.com/connect0459/rustgression/pull/159>
  - <https://github.com/connect0459/rustgression/pull/160>
  - <https://github.com/connect0459/rustgression/pull/161>
  - <https://github.com/connect0459/rustgression/pull/171>
  - <https://github.com/connect0459/rustgression/pull/172>
  - <https://github.com/connect0459/rustgression/pull/173>
  - <https://github.com/connect0459/rustgression/pull/174>
  - <https://github.com/connect0459/rustgression/pull/175>
  - <https://github.com/connect0459/rustgression/pull/176>
  - <https://github.com/connect0459/rustgression/pull/177>
  - <https://github.com/connect0459/rustgression/pull/178>
  - <https://github.com/connect0459/rustgression/pull/179>
  - <https://github.com/connect0459/rustgression/pull/180>
  - <https://github.com/connect0459/rustgression/pull/181>
  - <https://github.com/connect0459/rustgression/pull/182>
  - <https://github.com/connect0459/rustgression/pull/184>
  - <https://github.com/connect0459/rustgression/pull/186>
  - <https://github.com/connect0459/rustgression/pull/187>
  - <https://github.com/connect0459/rustgression/pull/189>
  - <https://github.com/connect0459/rustgression/pull/190>
  - <https://github.com/connect0459/rustgression/pull/191>
  - <https://github.com/connect0459/rustgression/pull/192>
  - <https://github.com/connect0459/rustgression/pull/193>
  - <https://github.com/connect0459/rustgression/pull/194>
  - <https://github.com/connect0459/rustgression/pull/195>
  - <https://github.com/connect0459/rustgression/pull/196>
  - <https://github.com/connect0459/rustgression/pull/197>
  - <https://github.com/connect0459/rustgression/pull/198>
  - <https://github.com/connect0459/rustgression/pull/199>

## [Required] Overview

Version bump to v0.6.0. Records all changes since v0.5.1 in `CHANGELOG.md` and
updates all version files via `just version-update 0.6.0`.

**What's new in v0.6.0:**

- **`OlsMultiRegressor`**: multi-predictor OLS regression backed by a Rust implementation;
  supports `predict()`, `r_squared()`, `f_statistic()`, `p_value()`, and `get_params()`;
  also accessible via `create_regressor(x, y, method="ols_multi")` (#175, #176, #177)
- **Goodness-of-fit diagnostics** on all single-predictor regressors: `r_squared()` and
  `residuals()` (#178)
- **Statistical inference for OLS**: `confidence_interval()` and `prediction_interval()`;
  `TlsRegressor` raises `NotImplementedError` — bootstrap TLS intervals are deferred (#179)
- **`NumericalWarning`**: subnormal input detection now surfaces through Python's `warnings`
  module so callers can suppress or escalate it (#182)
- **Bug fixes**: Deming stderr formula for TLS (#180), scale-aware `r_value()` for OLS (#181),
  `scipy` added to runtime dependencies (#179), `NoReturn` annotations on TLS interval stubs (#190),
  `__init__.pyi` stubs corrected for all v0.6.0 public symbols (#198)
- **Project layout**: Python package moved to `src-py/`, tests reorganised under
  `tests-py/integration/` and `tests-py/e2e/` (#184)
- **CHANGELOG**: release workflow guide and version comparison links added (#199)

## GitHub Release draft

<details>

<summary>Expand the GitHub Release draft</summary>

<!-- # v0.6.0 -->

## Added

- **`OlsMultiRegressor`**: new class for multi-predictor OLS regression backed by a Rust
  implementation (`calculate_ols_multi_regression`); supports `predict()`, `r_squared()`,
  `f_statistic()`, `p_value()`, and `get_params()`; also accessible via
  `create_regressor(x, y, method="ols_multi")` (#175, #176, #177)
- **`BaseRegressor`**: add `r_squared()` — coefficient of determination (R²) (#178)
- **`BaseRegressor`**: add `residuals()` — vertical residuals `y − ŷ` (#178)
- **`OlsRegressor`**: add `confidence_interval(alpha)` — t-based confidence intervals
  for slope and intercept (#179)
- **`OlsRegressor`**: add `prediction_interval(x_new, alpha)` — t-based prediction
  intervals for new observations; `TlsRegressor` raises `NotImplementedError` with an
  explanatory message — bootstrap TLS intervals are deferred (#179)
- **`NumericalWarning`**: new warning type emitted when subnormal input values are
  detected; exported from the package public API (#182)

## Bug Fixes

- **TLS**: replace OLS stderr formula with the Deming orthogonal-regression formula for
  more accurate slope and intercept standard errors (#180)
- **OLS**: fix product underflow in `r_value()` for sub-epsilon x variance using a
  scale-aware `compute_r_value` approach (#181)
- **OLS**: add overflow guard for intercept on extreme-scale inputs for consistency
  with slope (#181)
- **`TlsRegressor`**: `.pyi` stub now correctly declares `NoReturn` on
  `confidence_interval` and `prediction_interval` (#190)
- **deps**: add `scipy` to runtime dependencies (required by `confidence_interval` and
  `prediction_interval` but was previously missing) (#179)
- **`__init__.pyi`**: add missing exports (`NumericalWarning`, `OlsMultiRegressor`,
  `OlsMultiRegressionParams`) and `"ols_multi"` literal to `create_regressor` overload;
  resolves type errors for mypy/pyright users (#198)

## Changed

- **Numerical warnings**: diagnostics previously emitted via `eprintln!` are now routed
  through Python's `warnings` module so callers can suppress or escalate them (#182)
- **Project layout**: Python package moved from `rustgression/` to `src-py/rustgression/`;
  tests reorganised under `tests-py/integration/` and `tests-py/e2e/` tiers (#184)

---

## Full Changelog

[v0.5.1...v0.6.0](https://github.com/connect0459/rustgression/compare/v0.5.1...v0.6.0)

</details>

## Scope of Change

- [x] Rust core
- [x] Python bindings
- [x] Tooling / CI
- [x] Documentation

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- TLS confidence/prediction intervals (require bootstrap or jackknife methods) — tracked
  separately; `TlsRegressor` raises `NotImplementedError` with an explanatory message.
- `version-check.sh` does not normalise pre-release version strings before comparison
  (e.g. `0.7.0-alpha.1` vs `0.7.0a1`), causing `__init__.py` and `pyproject.toml`
  checks to always fail on alpha/beta releases. Deferred as it does not affect stable
  releases; tracked separately.
- `version-check.sh` does not validate that `CHANGELOG.md` contains an entry for the
  target version. A forgotten CHANGELOG update would pass `just version-check` silently.
  Deferred as a separate enhancement.
- `version-update.sh` next-steps message suggests `python -m pytest` but the project
  uses `uv run pytest`. Deferred as a cosmetic fix to the script output.

## Test Items

- No new code in this PR; all test coverage comes from the constituent PRs listed above.
- Both `cargo test` and `uv run pytest` pass on the release commit.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml) <!-- Run the workflow manually before checking this box. -->
- [x] **Code Comments**: Code comments and doc-comments are in sync with the changes
- [x] **Reference Docs**: `docs/api.md` is updated for any public API change
- [x] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
