### PR TITLE
chore: normalize pre-release version format in version-check.sh

### DIFF
--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -40,6 +40,9 @@ fi
 
 ARG_VERSION=$1
 
+# Derive the Python format of the version (e.g. 0.7.0-alpha.1 -> 0.7.0a1)
+PYTHON_VERSION=$(echo "$ARG_VERSION" | sed 's/-alpha\./a/' | sed 's/-beta\./b/' | sed 's/-rc\./rc/')
+
 # Function to compare semantic versions (returns 0 if v1 >= v2, 1 if v1 < v2)
 compare_versions() {
     local v1=$1
@@ -91,6 +94,9 @@ compare_versions() {
 
 echo "Checking version consistency..."
 echo "Expected version: $ARG_VERSION"
+if [ "$ARG_VERSION" != "$PYTHON_VERSION" ]; then
+    echo "Expected Python version: $PYTHON_VERSION"
+fi
 
 # Get version from src-py/rustgression/__init__.py
 INIT_VERSION=$(grep '^__version__ = ' src-py/rustgression/__init__.py | cut -d '"' -f2)
@@ -129,8 +135,8 @@ if [ -n "$CURRENT_CARGO_VERSION" ] && [ "$ARG_VERSION" != "$CURRENT_CARGO_VERSIO
     fi
 fi
 
-if [ "$ARG_VERSION" != "$INIT_VERSION" ]; then
-    error "[FAIL] src-py/rustgression/__init__.py version mismatch: expected=$ARG_VERSION, actual=$INIT_VERSION"
+if [ "$PYTHON_VERSION" != "$INIT_VERSION" ]; then
+    error "[FAIL] src-py/rustgression/__init__.py version mismatch: expected=$PYTHON_VERSION, actual=$INIT_VERSION"
     ERRORS=$((ERRORS + 1))
 else
     success "[PASS] src-py/rustgression/__init__.py"
@@ -143,8 +149,8 @@ else
     success "[PASS] Cargo.toml"
 fi
 
-if [ "$ARG_VERSION" != "$PYPROJECT_VERSION" ]; then
-    error "[FAIL] pyproject.toml version mismatch: expected=$ARG_VERSION, actual=$PYPROJECT_VERSION"
+if [ "$PYTHON_VERSION" != "$PYPROJECT_VERSION" ]; then
+    error "[FAIL] pyproject.toml version mismatch: expected=$PYTHON_VERSION, actual=$PYPROJECT_VERSION"
     ERRORS=$((ERRORS + 1))
 else
     success "[PASS] pyproject.toml"
@@ -157,8 +163,8 @@ else
     success "[PASS] Cargo.lock"
 fi
 
-if [ "$ARG_VERSION" != "$UV_LOCK_VERSION" ]; then
-    error "[FAIL] uv.lock version mismatch: expected=$ARG_VERSION, actual=$UV_LOCK_VERSION"
+if [ "$PYTHON_VERSION" != "$UV_LOCK_VERSION" ]; then
+    error "[FAIL] uv.lock version mismatch: expected=$PYTHON_VERSION, actual=$UV_LOCK_VERSION"
     ERRORS=$((ERRORS + 1))
 else
     success "[PASS] uv.lock"

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -40,8 +40,7 @@ fi
 
 ARG_VERSION=$1
 
-# Derive the Python format of the version (e.g. 0.7.0-alpha.1 -> 0.7.0a1)
-PYTHON_VERSION=$(echo "$ARG_VERSION" | sed 's/-alpha\./a/' | sed 's/-beta\./b/' | sed 's/-rc\./rc/')
+PYTHON_VERSION=$(echo "$ARG_VERSION" | sed 's/-alpha\./a/;s/-beta\./b/;s/-rc\./rc/')
 
 # Function to compare semantic versions (returns 0 if v1 >= v2, 1 if v1 < v2)
 compare_versions() {
@@ -125,11 +124,10 @@ echo "Version consistency check results:"
 ERRORS=0
 
 # Check for potential version downgrade
-CURRENT_CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)
-if [ -n "$CURRENT_CARGO_VERSION" ] && [ "$ARG_VERSION" != "$CURRENT_CARGO_VERSION" ]; then
-    if ! compare_versions "$ARG_VERSION" "$CURRENT_CARGO_VERSION"; then
+if [ -n "$CARGO_VERSION" ] && [ "$ARG_VERSION" != "$CARGO_VERSION" ]; then
+    if ! compare_versions "$ARG_VERSION" "$CARGO_VERSION"; then
         warning "WARNING: Potential version downgrade detected!"
-        warning "  Current Cargo.toml version: $CURRENT_CARGO_VERSION"
+        warning "  Current Cargo.toml version: $CARGO_VERSION"
         warning "  Expected version:           $ARG_VERSION"
         echo ""
     fi

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -40,6 +40,12 @@ fi
 
 ARG_VERSION=$1
 
+if ! [[ $ARG_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+|-beta\.[0-9]+|-rc\.[0-9]+)?$ ]]; then
+    error "Error: Version must be in semver format"
+    echo "Examples: 1.0.0, 1.0.0-alpha.1, 1.0.0-beta.2, 1.0.0-rc.1"
+    exit 1
+fi
+
 PYTHON_VERSION=$(echo "$ARG_VERSION" | sed 's/-alpha\./a/;s/-beta\./b/;s/-rc\./rc/')
 
 # Function to compare semantic versions (returns 0 if v1 >= v2, 1 if v1 < v2)

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -171,7 +171,11 @@ fi
 echo ""
 
 if [ $ERRORS -eq 0 ]; then
-    success "SUCCESS: All versions match: $ARG_VERSION"
+    if [ "$ARG_VERSION" != "$PYTHON_VERSION" ]; then
+        success "SUCCESS: All versions match (Rust: $ARG_VERSION / Python: $PYTHON_VERSION)"
+    else
+        success "SUCCESS: All versions match: $ARG_VERSION"
+    fi
     exit 0
 else
     error "ERROR: Found $ERRORS version inconsistencies"

--- a/scripts/version-update.sh
+++ b/scripts/version-update.sh
@@ -114,7 +114,7 @@ echo "Updating version to $NEW_VERSION..."
 
 # 1. Update __version__ in src-py/rustgression/__init__.py (convert alpha/beta format)
 echo "Updating src-py/rustgression/__init__.py..."
-PYTHON_VERSION=$(echo "$NEW_VERSION" | sed 's/-alpha\./.a/' | sed 's/-beta\./.b/' | sed 's/-rc\./.rc/')
+PYTHON_VERSION=$(echo "$NEW_VERSION" | sed 's/-alpha\./a/' | sed 's/-beta\./b/' | sed 's/-rc\./rc/')
 sed -i.bak "s/__version__ = \".*\"/__version__ = \"$PYTHON_VERSION\"/" src-py/rustgression/__init__.py
 
 # 2. Update version in Cargo.toml

--- a/scripts/version-update.sh
+++ b/scripts/version-update.sh
@@ -114,7 +114,7 @@ echo "Updating version to $NEW_VERSION..."
 
 # 1. Update __version__ in src-py/rustgression/__init__.py (convert alpha/beta format)
 echo "Updating src-py/rustgression/__init__.py..."
-PYTHON_VERSION=$(echo "$NEW_VERSION" | sed 's/-alpha\./a/' | sed 's/-beta\./b/' | sed 's/-rc\./rc/')
+PYTHON_VERSION=$(echo "$NEW_VERSION" | sed 's/-alpha\./a/;s/-beta\./b/;s/-rc\./rc/')
 sed -i.bak "s/__version__ = \".*\"/__version__ = \"$PYTHON_VERSION\"/" src-py/rustgression/__init__.py
 
 # 2. Update version in Cargo.toml


### PR DESCRIPTION
<!-- # chore: normalize pre-release version format in version-check.sh -->

## Related Links

- Issues
  - Closes <https://github.com/connect0459/rustgression/issues/203>
- PRs
  - N/A

## [Required] Overview

`just version-check 0.7.0-alpha.1` always exited non-zero even when all files had been
correctly updated, because the script compared the raw Rust-format input string
(`0.7.0-alpha.1`) directly against `__init__.py`, `pyproject.toml`, and `uv.lock`,
which store the PEP 440 form (`0.7.0a1`).

Two root causes were identified and fixed:

1. **`version-update.sh`** — the `sed` expressions that derive the Python format had a
   spurious leading dot, producing `0.7.0.a1` instead of the PEP 440 canonical form
   `0.7.0a1`. When `uv lock` ran it normalised the version to `0.7.0a1`, causing a
   persistent mismatch between what was written to `__init__.py`/`pyproject.toml` and
   what `uv.lock` stored.

2. **`version-check.sh`** — the script now derives `PYTHON_VERSION` from the input
   using the same (corrected) conversion, and uses it when comparing against Python-format
   files (`__init__.py`, `pyproject.toml`, `uv.lock`). The Rust-format string is still
   used for `Cargo.toml` and `Cargo.lock`.

Additional improvements made following code review:

- Input is validated against the accepted semver format before any comparison, matching
  the guard already present in `version-update.sh`. Non-canonical inputs such as
  `0.7.0-RC.1` (uppercase) or PEP 440 form (`0.7.0rc1`) are now rejected immediately
  with a clear diagnostic.
- The SUCCESS message for pre-release versions now reports both formats
  (`Rust: 0.7.0-alpha.1 / Python: 0.7.0a1`) so the summary accurately reflects what
  was validated against each file.
- Noise removed: an explanatory code comment, a redundant re-grep of `Cargo.toml`, and
  three chained `sed` pipes consolidated into a single expression (applied to both scripts).

Deliberately deferred: `compare_versions` duplication and its pre-existing parse edge
cases (#5–#9 from review) are out of scope for this bug fix.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- `compare_versions` is duplicated verbatim between both scripts, creating dual-maintenance
  risk. Extracting it to a shared source would require introducing `source`-based
  composition or a redesign of the scripts. Deferred as a separate enhancement.

## Test Items

- Manually validated the full update-then-check cycle for `alpha`, `beta`, and stable
  version strings; all exit 0 after the fix.
- Invalid inputs (`0.7.0-RC.1`, `0.7.0rc1`) are rejected at the validation step.
- No library code paths are affected; `cargo test` and `uv run pytest` are not required.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: Code comments and doc-comments are in sync with the changes
- [x] **Reference Docs**: `docs/api.md` is updated for any public API change
- [x] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
