### PR TITLE
chore: exit early when version-update is called with the current version

### DIFF
--- a/scripts/version-update.sh
+++ b/scripts/version-update.sh
@@ -30,7 +30,7 @@ if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+|-beta\.[0-9]+|-rc
 fi
 
 # Check for version downgrade by comparing with current Cargo.toml version
-CURRENT_CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)
+CURRENT_CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | cut -d '"' -f2 | tr -d '\r')
 if [ -n "$CURRENT_CARGO_VERSION" ]; then
     if [ "$NEW_VERSION" = "$CURRENT_CARGO_VERSION" ]; then
         info "Already at version $NEW_VERSION; nothing to do."

--- a/scripts/version-update.sh
+++ b/scripts/version-update.sh
@@ -32,6 +32,10 @@ fi
 # Check for version downgrade by comparing with current Cargo.toml version
 CURRENT_CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)
 if [ -n "$CURRENT_CARGO_VERSION" ]; then
+    if [ "$NEW_VERSION" = "$CURRENT_CARGO_VERSION" ]; then
+        info "Already at version $NEW_VERSION; nothing to do."
+        exit 0
+    fi
     if ! compare_versions "$NEW_VERSION" "$CURRENT_CARGO_VERSION"; then
         warning "WARNING: Version downgrade detected!"
         warning "  Current version: $CURRENT_CARGO_VERSION"

--- a/scripts/version-update.sh
+++ b/scripts/version-update.sh
@@ -33,8 +33,13 @@ fi
 CURRENT_CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | cut -d '"' -f2 | tr -d '\r')
 if [ -n "$CURRENT_CARGO_VERSION" ]; then
     if [ "$NEW_VERSION" = "$CURRENT_CARGO_VERSION" ]; then
-        info "Already at version $NEW_VERSION; nothing to do."
-        exit 0
+        _EXPECTED_PY=$(to_python_version "$NEW_VERSION")
+        _ACTUAL_PY_INIT=$(grep '^__version__ = ' src-py/rustgression/__init__.py | cut -d '"' -f2 | tr -d '\r')
+        _ACTUAL_PYPROJECT=$(grep '^version = ' pyproject.toml | head -1 | cut -d '"' -f2 | tr -d '\r')
+        if [ "$_ACTUAL_PY_INIT" = "$_EXPECTED_PY" ] && [ "$_ACTUAL_PYPROJECT" = "$_EXPECTED_PY" ]; then
+            info "Already at version $NEW_VERSION; nothing to do."
+            exit 0
+        fi
     fi
     if ! compare_versions "$NEW_VERSION" "$CURRENT_CARGO_VERSION"; then
         warning "WARNING: Version downgrade detected!"


### PR DESCRIPTION
<!-- # chore: exit early when version-update is called with the current version -->

## Related Links

- Issues
  - Closes <https://github.com/connect0459/rustgression/issues/209>
- PRs
  - N/A

## [Required] Overview

`just version-update <ver>` did not check whether the requested version already matched
the version recorded in the source files. Re-running the command with the current version
silently rewrote all version files with identical values and printed
`SUCCESS: Version update completed`, giving the false impression that a meaningful
update had occurred.

The script now detects the no-op case and exits early with
`Already at version X; nothing to do.` — but only when all three source version files
(`Cargo.toml`, `__init__.py`, `pyproject.toml`) already agree on the requested version.
If any file is out of sync (e.g. a prior run was interrupted mid-way), the full update
proceeds and restores consistency rather than exiting early.

Two additional hardening changes were made to the version-extraction grep pipeline:
`head -1` prevents a multi-value variable when `Cargo.toml` contains more than one
`version = "..."` line; `tr -d '\r'` guards against CRLF line endings on Windows clones.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- `read -p` in the downgrade-confirmation path silently exits 1 in non-interactive
  environments (CI). This is a pre-existing issue unrelated to this change and is
  deferred to a separate issue.

## Test Items

- No library code paths are affected; `cargo test` and `uv run pytest` are not required.
- Manually confirmed that `just version-update 0.6.0` (the current version, all files
  in sync) exits immediately with the informational message and no file writes.
- Manually confirmed that when `__init__.py` is set to a different version while
  `Cargo.toml` stays at `0.6.0`, `just version-update 0.6.0` proceeds with the full
  update instead of exiting early.
- Manually confirmed that `just version-update 0.5.0` still triggers the downgrade
  warning prompt as before.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: Code comments and doc-comments are in sync with the changes
- [x] **Reference Docs**: `docs/api.md` is updated for any public API change
- [x] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
