### PR TITLE
chore: restrict version scripts to [project] section when accessing pyproject.toml

### DIFF
--- a/scripts/libs/version-utils.sh
+++ b/scripts/libs/version-utils.sh
@@ -58,3 +58,14 @@ compare_versions() {
 
     if [ "$v1_pre_num" -ge "$v2_pre_num" ]; then return 0; else return 1; fi
 }
+
+_AWK_PYPROJECT_WRITE_VERSION='
+/^\[/ { in_project = ($0 == "[project]") }
+in_project && /^version = "/ { print "version = \"" ver "\""; next }
+{ print }
+'
+
+_AWK_PYPROJECT_READ_VERSION='
+/^\[/ { in_project = ($0 == "[project]") }
+in_project && /^version = "/ { print; exit }
+'

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -47,7 +47,7 @@ CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)
 echo "Cargo.toml version: $CARGO_VERSION"
 
 # Get version from pyproject.toml
-PYPROJECT_VERSION=$(grep '^version = ' pyproject.toml | cut -d '"' -f2)
+PYPROJECT_VERSION=$(awk "$_AWK_PYPROJECT_READ_VERSION" pyproject.toml | cut -d '"' -f2)
 echo "pyproject.toml version: $PYPROJECT_VERSION"
 
 # Get version from Cargo.lock

--- a/scripts/version-update.sh
+++ b/scripts/version-update.sh
@@ -35,7 +35,7 @@ if [ -n "$CURRENT_CARGO_VERSION" ]; then
     if [ "$NEW_VERSION" = "$CURRENT_CARGO_VERSION" ]; then
         _EXPECTED_PY=$(to_python_version "$NEW_VERSION")
         _ACTUAL_PY_INIT=$(grep '^__version__ = ' src-py/rustgression/__init__.py | cut -d '"' -f2 | tr -d '\r')
-        _ACTUAL_PYPROJECT=$(grep '^version = ' pyproject.toml | head -1 | cut -d '"' -f2 | tr -d '\r')
+        _ACTUAL_PYPROJECT=$(awk "$_AWK_PYPROJECT_READ_VERSION" pyproject.toml | cut -d '"' -f2 | tr -d '\r')
         if [ "$_ACTUAL_PY_INIT" = "$_EXPECTED_PY" ] && [ "$_ACTUAL_PYPROJECT" = "$_EXPECTED_PY" ]; then
             info "Already at version $NEW_VERSION; nothing to do."
             exit 0
@@ -67,7 +67,8 @@ sed -i.bak "s/^version = \".*\"/version = \"$NEW_VERSION\"/" Cargo.toml
 
 # 3. Update version in pyproject.toml (convert alpha/beta format)
 echo "Updating pyproject.toml..."
-sed -i.bak "s/^version = \".*\"/version = \"$PYTHON_VERSION\"/" pyproject.toml
+awk -v ver="$PYTHON_VERSION" "$_AWK_PYPROJECT_WRITE_VERSION" \
+    pyproject.toml > pyproject.toml.bak && mv pyproject.toml.bak pyproject.toml
 
 # 4. Update Cargo.lock (check project with cargo command)
 echo "Updating Cargo.lock..."

--- a/tests-py/scripts/test_version_scripts.py
+++ b/tests-py/scripts/test_version_scripts.py
@@ -1,0 +1,112 @@
+import shlex
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+_VERSION_UTILS = _PROJECT_ROOT / "scripts" / "libs" / "version-utils.sh"
+
+
+def _extract_section_versions(toml_text: str) -> dict[str, str]:
+    versions: dict[str, str] = {}
+    current_section: str | None = None
+    for line in toml_text.splitlines():
+        if line.startswith("["):
+            current_section = line
+        elif (
+            line.startswith('version = "')
+            and current_section is not None
+            and current_section not in versions
+        ):
+            versions[current_section] = line.split('"')[1]
+    return versions
+
+
+def _apply_version_write(pyproject_path: Path, new_version: str) -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source {shlex.quote(str(_VERSION_UTILS))} && "
+            f'awk -v ver={shlex.quote(new_version)} "$_AWK_PYPROJECT_WRITE_VERSION" '
+            f"{shlex.quote(str(pyproject_path))}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    pyproject_path.write_text(result.stdout)
+
+
+def _read_project_version(pyproject_path: Path) -> str:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source {shlex.quote(str(_VERSION_UTILS))} && "
+            f'awk "$_AWK_PYPROJECT_READ_VERSION" {shlex.quote(str(pyproject_path))} '
+            "| cut -d '\"' -f2",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def pyproject_with_tool_version(tmp_path: Path) -> Path:
+    p = tmp_path / "pyproject.toml"
+    p.write_text(
+        textwrap.dedent("""\
+            [project]
+            name = "testpkg"
+            version = "0.1.0"
+
+            [tool.some-tool]
+            version = "1.0.0"
+        """)
+    )
+    return p
+
+
+def test_version_write_leaves_tool_section_versions_unchanged(
+    pyproject_with_tool_version: Path,
+) -> None:
+    """Only the [project] version field is updated; [tool.*] entries are preserved."""
+    _apply_version_write(pyproject_with_tool_version, "0.2.0")
+    versions = _extract_section_versions(pyproject_with_tool_version.read_text())
+    assert versions["[project]"] == "0.2.0"
+    assert versions["[tool.some-tool]"] == "1.0.0"
+
+
+def test_version_write_preserves_all_tool_section_versions(tmp_path: Path) -> None:
+    """All [tool.*] version entries survive an update when multiple tool sections are present."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent("""\
+            [project]
+            name = "testpkg"
+            version = "0.1.0"
+
+            [tool.ruff]
+            version = "2.0.0"
+
+            [tool.mypy]
+            version = "3.0.0"
+        """)
+    )
+    _apply_version_write(pyproject, "0.2.0")
+    versions = _extract_section_versions(pyproject.read_text())
+    assert versions["[project]"] == "0.2.0"
+    assert versions["[tool.ruff]"] == "2.0.0"
+    assert versions["[tool.mypy]"] == "3.0.0"
+
+
+def test_version_read_returns_project_section_value_only(
+    pyproject_with_tool_version: Path,
+) -> None:
+    """Version extraction returns only the [project] value, ignoring [tool.*] entries."""
+    assert _read_project_version(pyproject_with_tool_version) == "0.1.0"

--- a/tests-py/scripts/test_version_scripts.py
+++ b/tests-py/scripts/test_version_scripts.py
@@ -1,9 +1,15 @@
 import shlex
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="version scripts are POSIX shell scripts, not applicable on Windows",
+)
 
 _PROJECT_ROOT = Path(__file__).parent.parent.parent
 _VERSION_UTILS = _PROJECT_ROOT / "scripts" / "libs" / "version-utils.sh"


### PR DESCRIPTION
<!-- # chore: restrict version scripts to [project] section when accessing pyproject.toml -->

## Related Links

- Issues
  - Closes <https://github.com/connect0459/rustgression/issues/210>
- PRs
  - N/A

## [Required] Overview

The `sed` and `grep` patterns used by the version scripts matched any `version = "..."`
line in `pyproject.toml` regardless of TOML section. If a `[tool.*]` block ever declared
a top-level `version = "..."` key, `version-update.sh` would silently overwrite it with
the package version, and `version-check.sh` would read the wrong value. The bug was
latent — `pyproject.toml` currently has only one such line — but the risk grows as the
file evolves.

Both the write path (updating the version) and the read paths (the no-op early-exit check
and the consistency check) are now restricted to the `[project]` section using an `awk`
`in_project` flag pattern. The write path was also migrated from `sed` to `awk` to avoid a
portability issue: BSD `sed` (macOS) rejects the inline block syntax `{s/.../...}/` that
GNU `sed` accepts.

The shared awk programs are defined once in `scripts/libs/version-utils.sh` and sourced
by both scripts, eliminating the dual-maintenance risk. Tests source the same constants
from `version-utils.sh` so test and production behavior are guaranteed to stay in sync.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- Three tests added in `tests-py/scripts/`:
  - Write path: only the `[project]` version is updated when `[tool.*]` sections also
    contain `version = "..."` entries (single and multiple tool sections).
  - Read path: version extraction returns only the `[project]` value when tool sections
    are present.
- Tests source the shared awk programs from `version-utils.sh`, so any change to the
  production awk logic is automatically reflected in the test assertions.
- No library code paths are affected; `cargo test` is not required.
- `uv run pytest` passes locally (156 tests).

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: Code comments and doc-comments are in sync with the changes
- [x] **Reference Docs**: `docs/api.md` is updated for any public API change
- [x] **Version Update** (for release PRs): Executed `just version-update <new-version>` to update all version files consistently

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
