### PR TITLE
docs: use feat/ prefix in branch naming example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/). Project-spe
 
 ## Pull request process
 
-1. Fork the repository and create a branch: `feature/xxx`, `fix/xxx`, `docs/xxx`.
+1. Fork the repository and create a branch: `feat/xxx`, `fix/xxx`, `docs/xxx`.
 2. Follow the Red → Green → Refactor cycle.
 3. Run `just lint` and `just test`, and ensure all pass.
 4. Open a pull request — CI runs Rust and Python test suites automatically.


### PR DESCRIPTION
<!-- # docs: use feat/ prefix in branch naming example -->

<!-- Remove unnecessary sections to keep the review focused -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

Updates the branch naming example in the pull request process section of `CONTRIBUTING.md`.

The example previously used `feature/xxx`, which does not match the `feat` type used throughout the project's Conventional Commits convention. It is now `feat/xxx`, keeping branch names consistent with commit type prefixes.

## Scope of Change

- [x] Documentation

## Breaking Changes

- [x] No breaking changes

Documentation-only change; no runtime behavior change.

## Deferred Items and TODOs

- N/A

## Test Items

- No tests added; the change is documentation only.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: No code changes
- [x] **Reference Docs**: No public API change; `docs/api.md` is unchanged

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
