### PR TITLE
docs: reorder README badges to put repo badges before external ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rustgression
 
-[![PyPI Downloads](https://static.pepy.tech/badge/rustgression)](https://pepy.tech/projects/rustgression)
 [![CI](https://github.com/connect0459/rustgression/actions/workflows/ci.yml/badge.svg)](https://github.com/connect0459/rustgression/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/connect0459/rustgression/blob/main/LICENSE)
+[![PyPI Downloads](https://static.pepy.tech/badge/rustgression)](https://pepy.tech/projects/rustgression)
 
 This project provides fast regression analysis (OLS, TLS) as a Python package.
 


### PR DESCRIPTION
<!-- # docs: reorder README badges to put repo badges before external ones -->

<!-- Remove unnecessary sections to keep the review focused -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

Reorders the badges at the top of `README.md` so that badges reflecting this repository's own state (CI status, license) come before badges sourced from external services (PyPI download count).

This groups self-descriptive project information first, with third-party stats following.

## Scope of Change

- [x] Documentation

## Breaking Changes

- [x] No breaking changes

Documentation-only change; no runtime behavior change.

## Deferred Items and TODOs

- N/A

## Test Items

- No tests added; the change is documentation only.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: No code changes
- [x] **Reference Docs**: No public API change; `docs/api.md` is unchanged

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
