### PR TITLE
docs: list pre-commit in Prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,10 @@
 
 ## Prerequisites
 
-- [just](https://just.systems/) — command runner
 - [rustup](https://rustup.rs/) — Rust toolchain manager (`rust-toolchain.toml` pins the version automatically)
 - [uv](https://docs.astral.sh/uv/) — Python package manager
+- [just](https://just.systems/) — command runner
+- [pre-commit](https://pre-commit.com/) — hook runner
 
 On Linux, the following system packages are required before running `just setup` (scipy depends on them):
 


### PR DESCRIPTION
<!-- # docs: list pre-commit in Prerequisites -->

<!-- Remove unnecessary sections to keep the review focused -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

`just setup` already installs the pre-commit hooks, but pre-commit itself
was missing from `CONTRIBUTING.md`'s `## Prerequisites` list, so a
first-time contributor reading only that section wouldn't know it needs to
be installed beforehand.

This adds pre-commit to Prerequisites, matching the style already used in
`gh-exhibit`.

## Scope of Change

- [x] Documentation

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- Documentation-only change; no code affected. Verified
  `uv run pre-commit run --all-files` passes.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Documentation-only change; no Rust or Python source touched, so the CI workflow's build/lint/test steps do not apply.
- [x] **Code Comments**: No code changes.
- [x] **Reference Docs**: N/A — this only affects `CONTRIBUTING.md`, not `docs/api.md`.
- [x] **Version Update**: N/A — not a release PR.

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
