### PR TITLE
chore(rust): link cargo test against the uv-managed venv Python

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+PYO3_PYTHON = { value = ".venv/bin/python3", relative = true }


### PR DESCRIPTION
<!-- # chore(rust): link cargo test against the uv-managed venv Python -->

<!-- Remove unnecessary sections to keep the review focused -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

Without a project-level cargo config, `cargo build`/`cargo test` resolves
pyo3's link target by picking up whichever `python3` happens to be first on
`PATH`. Locally that could silently link against an unrelated Homebrew
Python install rather than the `>=3.11` interpreter that `uv sync` /
`maturin develop` actually use for this project — a mismatch that produces
no build error, only a linked ABI that doesn't match the one Python and
pytest exercise.

`.cargo/config.toml` now sets `PYO3_PYTHON` to `.venv/bin/python3`,
resolved relative to the workspace root. This makes `cargo test` link
against the same interpreter every other tool in the project uses, and
does so without hardcoding any machine-specific path — the setting works
for any contributor once they've run `just setup`.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- Verified with a clean rebuild (`cargo clean -p rustgression && cargo test`) that the built library links against the `.venv` interpreter's `libpython3.11.dylib`, not the system `python3`.
- `cargo test` passes (95 tests, 0 failures).

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: No code comments added.
- [x] **Reference Docs**: N/A — build configuration only, no public API change.
- [x] **Version Update**: N/A — not a release PR.

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
