### PR TITLE
feat: append a Full Changelog comparison link to the Release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,23 @@ jobs:
             exit 1
           fi
 
+          # Append a Full Changelog comparison link, reusing the compare URL
+          # CHANGELOG.md's own reference-link section already tracks for this
+          # version (skipped for the very first release, which links to the
+          # tag itself rather than a compare view).
+          COMPARE_URL="$(awk -v ver="$RELEASE_VERSION" '
+            index($0, "[" ver "]: ") == 1 {
+              sub(/^\[[^]]*\]: </, "")
+              sub(/>$/, "")
+              print
+              exit
+            }
+          ' CHANGELOG.md)"
+
+          if [[ "$COMPARE_URL" == *"/compare/"* ]]; then
+            printf '\n**Full Changelog**: %s\n' "$COMPARE_URL" >> release-notes.md
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,9 +172,9 @@ jobs:
           fi
 
           # Append a Full Changelog comparison link, reusing the compare URL
-          # CHANGELOG.md's own reference-link section already tracks for this
-          # version (skipped for the very first release, which links to the
-          # tag itself rather than a compare view).
+          # that CHANGELOG.md's own reference-link section already records
+          # for this version (skipped for the very first release, which
+          # links to the tag itself rather than a compare view).
           COMPARE_URL="$(awk -v ver="$RELEASE_VERSION" '
             index($0, "[" ver "]: ") == 1 {
               sub(/^\[[^]]*\]: </, "")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,10 +171,11 @@ jobs:
             exit 1
           fi
 
-          # Append a Full Changelog comparison link, reusing the compare URL
-          # that CHANGELOG.md's own reference-link section already records
-          # for this version (skipped for the very first release, which
-          # links to the tag itself rather than a compare view).
+          # Append a Full Changelog link, reusing the compare URL that
+          # CHANGELOG.md's own reference-link section already records for
+          # this version. The very first release's reference link points at
+          # the tag itself rather than a compare view, so link the tag name
+          # to its commit history instead.
           COMPARE_URL="$(awk -v ver="$RELEASE_VERSION" '
             index($0, "[" ver "]: ") == 1 {
               sub(/^\[[^]]*\]: </, "")
@@ -186,6 +187,10 @@ jobs:
 
           if [[ "$COMPARE_URL" == *"/compare/"* ]]; then
             printf '\n**Full Changelog**: %s\n' "$COMPARE_URL" >> release-notes.md
+          elif [ -n "$COMPARE_URL" ]; then
+            printf '\n**Full Changelog**: [%s](%s/%s/commits/%s)\n' \
+              "$GITHUB_REF_NAME" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" \
+              >> release-notes.md
           fi
 
       - name: Create GitHub Release


### PR DESCRIPTION
<!-- # feat: append a Full Changelog comparison link to the Release body -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

`CHANGELOG.md`'s own reference-link section already tracks a compare URL for each version (e.g. `[X.Y.Z]: <.../compare/vPREV...vX.Y.Z>`), but that's a Markdown reference definition — invisible in the rendered changelog, and never carried into the auto-generated GitHub Release body, unlike the "**Full Changelog**" link GitHub's own release notes include.

The release workflow now reads that same compare URL and appends it as a visible line at the end of the Release body, matching that convention. The very first release, whose reference link points at the tag itself rather than a compare view, is left without one.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- No Rust or Python code changed; `cargo test` / `uv run pytest` are unaffected.
- Verified locally against this repo's own `CHANGELOG.md` that the extraction produces the expected compare URL for a mid-history version and correctly produces no link for the first release.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: No code comments added; the new workflow step's comment explains why the first release is skipped.
- [x] **Reference Docs**: N/A — no public API change.
- [x] **Version Update**: N/A — not a release PR.

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
