### PR TITLE
fix: promote CHANGELOG heading levels in extracted release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,12 @@ jobs:
             capture { print }
           ' CHANGELOG.md > release-notes.md
 
+          # Keep a Changelog nests each entry's subsections one level deeper
+          # (###, ####, ...) than the version heading (##) this extraction
+          # strips out. Promote every heading by one level so the release
+          # body reads as a normal document instead of starting at H3.
+          sed -i -E 's/^#(#{2,}) /\1 /' release-notes.md
+
           if [ ! -s release-notes.md ]; then
             echo "::error::No CHANGELOG.md section found for [$RELEASE_VERSION]. Retitle [Unreleased] to [$RELEASE_VERSION] - YYYY-MM-DD before tagging."
             exit 1


### PR DESCRIPTION
<!-- # fix: promote CHANGELOG heading levels in extracted release notes -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

Keep a Changelog nests each version's subsections (`### Added`, `### Fixed`, ...) one level under the version heading (`## [X.Y.Z]`) that the release workflow strips out when extracting a single version's section. Left untouched, the resulting Release body started at H3 with no parent heading, unlike the H2-level sections a hand-written Release used to start with.

Every heading in the extracted body is now promoted by one level, so `### Added` becomes `## Added` and any deeper `#### Subsection` becomes `### Subsection`, preserving the relative hierarchy. Verified against every existing `CHANGELOG.md` entry in this repo and its sibling repos that none of them have a fenced code block containing a heading-like line, which a blind line-start substitution like this would otherwise mangle.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- No Rust or Python code changed; `cargo test` / `uv run pytest` are unaffected.
- Verified locally against this repo's own `CHANGELOG.md` (including a version with a nested `####` subsection) that the substitution promotes every heading level by exactly one without touching list items or body text.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: No code comments added; the new workflow step's comment explains the heading-level mismatch it corrects.
- [x] **Reference Docs**: N/A — no public API change.
- [x] **Version Update**: N/A — not a release PR.

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
