### PR TITLE
fix: clean up Full Changelog rendering in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
             exit 1
           fi
 
-          # Append a Full Changelog link, reusing the compare URL that
+          # Append a Full Changelog section, reusing the compare URL that
           # CHANGELOG.md's own reference-link section already records for
           # this version. The very first release's reference link points at
           # the tag itself rather than a compare view, so link the tag name
@@ -197,11 +197,16 @@ jobs:
           ' CHANGELOG.md)"
 
           if [[ "$COMPARE_URL" == *"/compare/"* ]]; then
-            printf '\n**Full Changelog**: %s\n' "$COMPARE_URL" >> release-notes.md
+            FULL_CHANGELOG_LABEL="${COMPARE_URL##*/}"
+            FULL_CHANGELOG_URL="$COMPARE_URL"
           elif [ -n "$COMPARE_URL" ]; then
-            printf '\n**Full Changelog**: [%s](%s/%s/commits/%s)\n' \
-              "$GITHUB_REF_NAME" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" \
-              >> release-notes.md
+            FULL_CHANGELOG_LABEL="$GITHUB_REF_NAME"
+            FULL_CHANGELOG_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commits/$GITHUB_REF_NAME"
+          fi
+
+          if [ -n "$FULL_CHANGELOG_URL" ]; then
+            printf '\n---\n\n## Full Changelog\n\n[%s](%s)\n' \
+              "$FULL_CHANGELOG_LABEL" "$FULL_CHANGELOG_URL" >> release-notes.md
           fi
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,8 @@ jobs:
             }
           ' CHANGELOG.md)"
 
+          FULL_CHANGELOG_LABEL=""
+          FULL_CHANGELOG_URL=""
           if [[ "$COMPARE_URL" == *"/compare/"* ]]; then
             FULL_CHANGELOG_LABEL="${COMPARE_URL##*/}"
             FULL_CHANGELOG_URL="$COMPARE_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,11 @@ jobs:
             capture { print }
           ' CHANGELOG.md > release-notes.md
 
+          # Drop trailing blank lines so appending the Full Changelog link
+          # below doesn't leave two blank lines before it.
+          awk '{a[NR]=$0} END {n=NR; while (n>0 && a[n] ~ /^[[:space:]]*$/) n--; for (i=1;i<=n;i++) print a[i]}' release-notes.md > release-notes.md.tmp
+          mv release-notes.md.tmp release-notes.md
+
           # Keep a Changelog nests each entry's subsections one level deeper
           # (###, ####, ...) than the version heading (##) this extraction
           # strips out. Promote every heading by one level so the release


### PR DESCRIPTION
<!-- # fix: drop trailing blank lines before the Full Changelog link -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

The extracted CHANGELOG section already ends with a blank line before the next version heading or the reference-links separator, and appending the Full Changelog link added another blank line on top of it — leaving two blank lines in the Release body instead of the one a hand-written Release would have.

Trailing blank lines are now trimmed from the extracted section before the link is appended, so exactly one blank line separates the changelog content from it.

A follow-up commit also changes the link's rendering from an inline `**Full Changelog**: <url>` line to its own section: a horizontal rule, a `## Full Changelog` heading, and a link labeled with the tag range (e.g. `v0.6.0...v0.7.0`) instead of the raw URL — or just the tag itself for a repo's very first release.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- No Rust or Python code changed; `cargo test` / `uv run pytest` are unaffected.
- Verified locally against this repo's own `CHANGELOG.md` that the trimmed extraction plus the appended link produces exactly one blank line, where it previously produced two.
- Verified locally that the rendered section matches the requested format for both a compare-link version and a repo's very first release.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: No code comments added; the new workflow step's comment explains why the trim is needed.
- [x] **Reference Docs**: N/A — no public API change.
- [x] **Version Update**: N/A — not a release PR.

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
