### PR TITLE
ci: replace inline changelog extraction with extract-changelog action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,68 +154,16 @@ jobs:
           persist-credentials: false
 
       - name: Extract changelog section for this version
-        shell: bash
-        run: |
-          RELEASE_VERSION="${GITHUB_REF_NAME#v}"
-          awk -v ver="$RELEASE_VERSION" '
-            /^## \[/ {
-              if (capture) exit
-              if (index($0, "## [" ver "]") == 1) { capture = 1; next }
-            }
-            /^---/ { if (capture) exit }
-            capture { print }
-          ' CHANGELOG.md > release-notes.md
-
-          # Drop trailing blank lines so appending the Full Changelog link
-          # below doesn't leave two blank lines before it.
-          awk '{a[NR]=$0} END {n=NR; while (n>0 && a[n] ~ /^[[:space:]]*$/) n--; for (i=1;i<=n;i++) print a[i]}' release-notes.md > release-notes.md.tmp
-          mv release-notes.md.tmp release-notes.md
-
-          # Keep a Changelog nests each entry's subsections one level deeper
-          # (###, ####, ...) than the version heading (##) this extraction
-          # strips out. Promote every heading by one level so the release
-          # body reads as a normal document instead of starting at H3.
-          sed -i -E 's/^#(#{2,}) /\1 /' release-notes.md
-
-          if [ ! -s release-notes.md ]; then
-            echo "::error::No CHANGELOG.md section found for [$RELEASE_VERSION]. Retitle [Unreleased] to [$RELEASE_VERSION] - YYYY-MM-DD before tagging."
-            exit 1
-          fi
-
-          # Append a Full Changelog section, reusing the compare URL that
-          # CHANGELOG.md's own reference-link section already records for
-          # this version. The very first release's reference link points at
-          # the tag itself rather than a compare view, so link the tag name
-          # to its commit history instead.
-          COMPARE_URL="$(awk -v ver="$RELEASE_VERSION" '
-            index($0, "[" ver "]: ") == 1 {
-              sub(/^\[[^]]*\]: </, "")
-              sub(/>$/, "")
-              print
-              exit
-            }
-          ' CHANGELOG.md)"
-
-          FULL_CHANGELOG_LABEL=""
-          FULL_CHANGELOG_URL=""
-          if [[ "$COMPARE_URL" == *"/compare/"* ]]; then
-            FULL_CHANGELOG_LABEL="${COMPARE_URL##*/}"
-            FULL_CHANGELOG_URL="$COMPARE_URL"
-          elif [ -n "$COMPARE_URL" ]; then
-            FULL_CHANGELOG_LABEL="$GITHUB_REF_NAME"
-            FULL_CHANGELOG_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commits/$GITHUB_REF_NAME"
-          fi
-
-          if [ -n "$FULL_CHANGELOG_URL" ]; then
-            printf '\n---\n\n## Full Changelog\n\n[%s](%s)\n' \
-              "$FULL_CHANGELOG_LABEL" "$FULL_CHANGELOG_URL" >> release-notes.md
-          fi
+        id: changelog
+        uses: connect0459/extract-changelog@d1a123486c1f4d24327a5d28c7ffa5c788b02a04 # v1.0.0
+        with:
+          ref-name: ${{ github.ref_name }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: ${{ github.ref_name }}
-          body_path: release-notes.md
+          body_path: ${{ steps.changelog.outputs.release-notes-path }}
 
   # Step 4: Publish all wheels to PyPI after successful builds
   publish:


### PR DESCRIPTION
<!-- # ci: replace inline changelog extraction with extract-changelog action -->

## Related Links

- Issues
  - N/A
- PRs
  - N/A

## [Required] Overview

`release.yml`'s changelog-extraction step was a verbatim copy of logic that also ran, unchanged, in several sibling repos — the exact kind of duplication `connect0459/extract-changelog` (published as its own composite GitHub Action, `v1.0.0`) exists to remove. A fix to the extraction logic here previously meant hand-patching every repo that carried a copy of it.

This PR replaces the inline script with `uses: connect0459/extract-changelog@<sha> # v1.0.0`, pinned by commit hash to match this repo's convention for third-party actions. The step's `release-notes-path` output now feeds `softprops/action-gh-release`'s `body_path` directly, instead of both steps agreeing on a hardcoded `release-notes.md` filename.

## Scope of Change

- [x] Tooling / CI

## Breaking Changes

- [x] No breaking changes

## Deferred Items and TODOs

- N/A

## Test Items

- No Rust or Python code changed; `cargo test` / `uv run pytest` are unaffected.
- `actionlint` passes on the updated workflow; pre-commit's own hook set for this repo doesn't lint workflow files, so this was checked directly.
- The actual tag-triggered run can only be validated once a real tag is pushed, same as before this change — no local GitHub Actions runner available.

## [Required] Quality Checklist

**Please check all items before merging.**

- [x] **CI Workflow Execution**: Full quality check completed by manually running `Run workflow` in [Actions](../actions/workflows/ci.yml)
- [x] **Code Comments**: No code comments added; the removed inline script's rationale comments are no longer needed now that the logic lives in the referenced action.
- [x] **Reference Docs**: N/A — no public API change.
- [x] **Version Update**: N/A — not a release PR.

> **Important**: This checklist ensures quality. Please verify all items before requesting review.
